### PR TITLE
Switch native build to new docker image (#78)

### DIFF
--- a/tools/build/build_native.sh
+++ b/tools/build/build_native.sh
@@ -102,6 +102,6 @@ docker run --rm -t ${INTERACTIVE} ${USERID} -v ${PWD}:/source \
     "${CONAN_HOME_MP[@]}" \
     -w /source/prod/native \
     -e GITHUB_SHA=${GITHUB_SHA} \
-    otel/opentelemetry-php-distro-dev:native-build-${BUILD_ARCHITECTURE}-gcc15.2.0-v0.0.2-conancache-v0.0.1 \
+    otel/opentelemetry-php-distro-dev:native-build-${BUILD_ARCHITECTURE}-gcc15.2.0-v0.0.2-conancache-v0.0.2 \
     sh -c "id && echo CONAN_HOME: \$CONAN_HOME && ${CONFIGURE} cmake --build --preset ${BUILD_ARCHITECTURE}-release ${NCPU} && ${UNIT_TESTS}"
 


### PR DESCRIPTION
Update the native build docker image from conancache-v0.0.1 to conancache-v0.0.2 in build script.

The new Conan cache image (conancache-v0.0.2) contains pre-cached Conan dependencies built with PHP 8.5 headers included. This eliminates the need to fetch and build these dependencies during CI, significantly reducing native build times.
