### PR TITLE
OpAmp config improvements

### DIFF
--- a/prod/native/extension/code/Hooking.cpp
+++ b/prod/native/extension/code/Hooking.cpp
@@ -113,13 +113,21 @@ static zend_op_array *otel_compile_file(zend_file_handle *file_handle, int type)
     return ret;
 }
 
-void Hooking::replaceHooks(bool enableInferredSpansHooks, bool enableDepenecyAutoloaderGuard) {
+void Hooking::enableInferredSpansHooks() {
+    if (inferredSpansHooksInstalled_) {
+        return;
+    }
+    ELOGF_DEBUG(OTEL_G(globals)->logger_, HOOKS, "Hooked into zend_execute_internal and zend_interrupt_function");
+    zend_execute_internal = otel_execute_internal;
+    zend_interrupt_function = otel_interrupt_function;
+    inferredSpansHooksInstalled_ = true;
+}
+
+void Hooking::replaceHooks(bool enableInferredSpansHook, bool enableDepenecyAutoloaderGuard) {
     zend_observer_error_register(otel_observer_error_cb);
 
-    if (enableInferredSpansHooks) {
-        ELOGF_DEBUG(OTEL_G(globals)->logger_, HOOKS, "Hooked into zend_execute_internal and zend_interrupt_function");
-        zend_execute_internal = otel_execute_internal;
-        zend_interrupt_function = otel_interrupt_function;
+    if (enableInferredSpansHook) {
+        enableInferredSpansHooks();
     }
 
     if (enableDepenecyAutoloaderGuard) {

--- a/prod/native/extension/code/Hooking.h
+++ b/prod/native/extension/code/Hooking.h
@@ -41,6 +41,7 @@ public:
     }
 
     void replaceHooks(bool enableInferredSpansHooks, bool enableDepenecyAutoloaderGuard);
+    void enableInferredSpansHooks();
 
 private:
     Hooking(Hooking const &) = delete;
@@ -50,6 +51,7 @@ private:
     zend_execute_internal_t original_execute_internal_ = nullptr;
     zend_interrupt_function_t original_zend_interrupt_function_ = nullptr;
     zend_compile_file_t original_zend_compile_file_ = nullptr;
+    bool inferredSpansHooksInstalled_ = false;
 };
 
 } // namespace opentelemetry::php

--- a/prod/native/extension/code/ModuleEntry.cpp
+++ b/prod/native/extension/code/ModuleEntry.cpp
@@ -23,6 +23,7 @@
 #include "ModuleFunctions.h"
 #include "PhpBridge.h"
 #include "PhpBridgeInterface.h"
+#include "Hooking.h"
 #include "RequestScope.h"
 #include "ResourceDetector.h"
 #include "SigSegvHandler.h"
@@ -38,6 +39,12 @@ ZEND_DECLARE_MODULE_GLOBALS( opentelemetry_distro )
 
 PHP_RINIT_FUNCTION(opentelemetry_distro) {
     OTEL_G(globals)->requestScope_->onRequestInit();
+
+    // Install inferred spans hooks if enabled (handles remote config enabling after MINIT)
+    if (OTEL_G(globals)->config_->get().inferred_spans_enabled) {
+        opentelemetry::php::Hooking::getInstance().enableInferredSpansHooks();
+    }
+
     return SUCCESS;
 }
 

--- a/prod/native/libcommon/code/AgentGlobals.cpp
+++ b/prod/native/libcommon/code/AgentGlobals.cpp
@@ -64,6 +64,10 @@ AgentGlobals::AgentGlobals(std::shared_ptr<LoggerInterface> logger,
     {
         forkableRegistry_->registerForkable(workerRegistrar_);
 
+        if (vendorCustomizations_) {
+            vendorCustomizations_->setLogger(logger_);
+        }
+
         config_->addConfigUpdateWatcher(loggerConfigUpdateFunc);
 }
 

--- a/prod/native/libcommon/code/ConfigurationManager.h
+++ b/prod/native/libcommon/code/ConfigurationManager.h
@@ -115,6 +115,7 @@ private:
         BUILD_OTEL_PHP_OPTION_METADATA(OTEL_PHP_OPAMP_HEADERS, OptionMetadata::type::string, false),
         BUILD_OTEL_PHP_OPTION_METADATA(OTEL_PHP_OPAMP_ENDPOINT, OptionMetadata::type::string, false),
         BUILD_OTEL_PHP_OPTION_METADATA(OTEL_PHP_OPAMP_HEARTBEAT_INTERVAL, OptionMetadata::type::duration, false),
+        BUILD_OTEL_PHP_OPTION_METADATA(OTEL_PHP_OPAMP_POLLING_INTERVAL, OptionMetadata::type::duration, false),
         BUILD_OTEL_PHP_OPTION_METADATA(OTEL_PHP_OPAMP_SEND_TIMEOUT, OptionMetadata::type::duration, false),
         BUILD_OTEL_PHP_OPTION_METADATA(OTEL_PHP_OPAMP_SEND_MAX_RETRIES, OptionMetadata::type::bytes, false),
         BUILD_OTEL_PHP_OPTION_METADATA(OTEL_PHP_OPAMP_SEND_RETRY_DELAY, OptionMetadata::type::duration, false),

--- a/prod/native/libcommon/code/ConfigurationSnapshot.h
+++ b/prod/native/libcommon/code/ConfigurationSnapshot.h
@@ -42,6 +42,7 @@
 #define OTEL_PHP_OPAMP_ENDPOINT opamp_endpoint
 
 #define OTEL_PHP_OPAMP_HEARTBEAT_INTERVAL opamp_heartbeat_interval
+#define OTEL_PHP_OPAMP_POLLING_INTERVAL opamp_polling_interval
 #define OTEL_PHP_OPAMP_SEND_TIMEOUT opamp_send_timeout
 #define OTEL_PHP_OPAMP_SEND_MAX_RETRIES opamp_send_max_retries
 #define OTEL_PHP_OPAMP_SEND_RETRY_DELAY opamp_send_retry_delay
@@ -119,6 +120,7 @@ struct ConfigurationSnapshot {
     std::string OTEL_PHP_OPAMP_HEADERS;
     std::string OTEL_PHP_OPAMP_ENDPOINT;
     std::chrono::milliseconds OTEL_PHP_OPAMP_HEARTBEAT_INTERVAL = 30s;
+    std::chrono::milliseconds OTEL_PHP_OPAMP_POLLING_INTERVAL = 30s;
     std::chrono::milliseconds OTEL_PHP_OPAMP_SEND_TIMEOUT = 10s;
     std::size_t OTEL_PHP_OPAMP_SEND_MAX_RETRIES = 3;
     std::chrono::milliseconds OTEL_PHP_OPAMP_SEND_RETRY_DELAY = 10s;

--- a/prod/native/libcommon/code/ResourceDetector.h
+++ b/prod/native/libcommon/code/ResourceDetector.h
@@ -45,6 +45,10 @@ public:
         return resourceAttributes_.end();
     }
 
+    void addAttributes(std::map<std::string, std::string> const &attrs) {
+        resourceAttributes_.insert(attrs.begin(), attrs.end());
+    }
+
 protected:
     void getFromEnvironment();
     void getHostAndOsAttributes();

--- a/prod/native/libcommon/code/VendorCustomizationsInterface.h
+++ b/prod/native/libcommon/code/VendorCustomizationsInterface.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "config/OptionValueProviderInterface.h"
+#include "LoggerInterface.h"
 
+#include <map>
 #include <string>
 #include <memory>
 #include <utility>
@@ -22,6 +24,10 @@ public:
     virtual std::string getUserAgent() const = 0;
 
     virtual std::pair<int, std::shared_ptr<opentelemetry::php::config::OptionValueProviderInterface>>  getOptionValueProvider() = 0;
+
+    virtual void setLogger(std::shared_ptr<LoggerInterface> logger) = 0;
+
+    virtual std::map<std::string, std::string> getAdditionalResourceAttributes() = 0;
 };
 
 }

--- a/prod/native/libcommon/code/coordinator/CoordinatorProcess.cpp
+++ b/prod/native/libcommon/code/coordinator/CoordinatorProcess.cpp
@@ -35,15 +35,30 @@ CoordinatorProcess::CoordinatorProcess(
             config_(std::make_shared<opentelemetry::php::ConfigurationStorage>([this](ConfigurationSnapshot &cfg) { return configManager_->updateIfChanged(cfg); })),
             workerRegistry_(std::make_shared<WorkerRegistry>(logger_)),
             httpTransport_(std::make_shared<transport::HttpTransportAsync<>>(logger_, config_)),
-            opAmp_(std::make_shared<opentelemetry::php::transport::OpAmp>(logger_, config_, httpTransport_, std::move(resourceDetector))),
+            opAmp_(std::make_shared<opentelemetry::php::transport::OpAmp>(logger_, config_, httpTransport_, [&]() {
+                if (vendorCustomizations_) {
+                    resourceDetector->addAttributes(vendorCustomizations_->getAdditionalResourceAttributes());
+                }
+                return std::move(resourceDetector);
+            }())),
             messagesDispatcher_(std::make_shared<CoordinatorMessagesDispatcher>(logger_, httpTransport_, workerRegistry_)),
             processor_{logger_, sharedDataQueue, [this](const std::span<const std::byte> data) { messagesDispatcher_->processRecievedMessage(data); }},
             configProvider_(std::move(configProvider)) {
 
+        if (vendorCustomizations_) {
+            vendorCustomizations_->setLogger(logger_);
+        }
+
         opAmp_->addConfigUpdateWatcher([this](opentelemetry::php::transport::OpAmp::configFiles_t const &configFiles) {
             configProvider_->storeConfigFiles(configFiles);
+            configManager_->update(configFiles);
+            config_->update();
         });
         config_->addConfigUpdateWatcher(loggerConfigUpdateFunc);
+        config_->addConfigUpdateWatcher([this](opentelemetry::php::ConfigurationSnapshot const &cfg) {
+            opAmp_->updateHeartbeatInterval(cfg.opamp_heartbeat_interval);
+            opAmp_->updatePollingInterval(cfg.opamp_polling_interval);
+        });
 
         configManager_->update();
         config_->update();

--- a/prod/native/libcommon/code/transport/OpAmp.cpp
+++ b/prod/native/libcommon/code/transport/OpAmp.cpp
@@ -41,9 +41,10 @@ void OpAmp::startCommunication() {
     }
 
     endpointHash_ = std::hash<std::string>{}(endpointUrl);
-    heartbeatInterval_ = {std::chrono::duration_cast<std::chrono::seconds>(config_->get().opamp_heartbeat_interval)};
+    heartbeatInterval_ = config_->get().opamp_heartbeat_interval;
+    pollingInterval_ = config_->get().opamp_polling_interval;
 
-    ELOG_DEBUG(log_, OPAMP, "Agent UID: '{}', endpoint: '{}', endpoint hash: '{:X}', heartbeat interval: {}ms", boost::uuids::to_string(agentUid_), endpointUrl, endpointHash_, heartbeatInterval_.load());
+    ELOG_DEBUG(log_, OPAMP, "Agent UID: '{}', endpoint: '{}', endpoint hash: '{:X}', heartbeat interval: {}ms, polling interval: {}ms", boost::uuids::to_string(agentUid_), endpointUrl, endpointHash_, heartbeatInterval_.load().count(), pollingInterval_.load().count());
     for (auto const &[k, v] : endpointHeaders) {
         ELOG_DEBUG(log_, OPAMP, "Header: '{}: {}'", k, v);
     }

--- a/prod/native/libcommon/code/transport/OpAmp.h
+++ b/prod/native/libcommon/code/transport/OpAmp.h
@@ -70,6 +70,22 @@ public:
         configUpdatedWatchers_.disconnect_all_slots();
     }
 
+    void updateHeartbeatInterval(std::chrono::milliseconds interval) {
+        if (interval.count() > 0) {
+            ELOG_DEBUG(log_, OPAMP, "Updating heartbeat interval to {}ms", interval.count());
+            heartbeatInterval_ = interval;
+            pauseCondition_.notify_all();
+        }
+    }
+
+    void updatePollingInterval(std::chrono::milliseconds interval) {
+        if (interval.count() > 0) {
+            ELOG_DEBUG(log_, OPAMP, "Updating polling interval to {}ms", interval.count());
+            pollingInterval_ = interval;
+            pauseCondition_.notify_all();
+        }
+    }
+
 protected:
     void sendInitialAgentToServer();
     void handleServerToAgent(const char *data, std::size_t size);
@@ -107,18 +123,37 @@ protected:
 
         opentelemetry::utils::blockApacheAndPHPSignals();
 
+        auto now = std::chrono::steady_clock::now();
+        auto nextHeartbeat = now + heartbeatInterval_.load();
+        auto nextPoll = now + pollingInterval_.load();
+
         std::unique_lock<std::mutex> lock(mutex_);
         while (working_) {
-            pauseCondition_.wait_for(lock, heartbeatInterval_.load(), [this]() -> bool { return !working_; });
+            auto waitUntil = std::min(nextHeartbeat, nextPoll);
+            pauseCondition_.wait_until(lock, waitUntil, [this, &waitUntil]() -> bool { return !working_ || std::chrono::steady_clock::now() >= waitUntil; });
 
             if (!working_ && !forceFlushOnDestruction_) {
                 break;
             }
 
-            try {
-                sendHeartbeat();
-            } catch (std::exception const &e) {
-                ELOG_WARNING(log_, OPAMP, "Unable to send heartbeat {}", e.what());
+            now = std::chrono::steady_clock::now();
+            bool shouldSend = false;
+
+            if (now >= nextHeartbeat) {
+                shouldSend = true;
+                nextHeartbeat = now + heartbeatInterval_.load();
+            }
+            if (now >= nextPoll) {
+                shouldSend = true;
+                nextPoll = now + pollingInterval_.load();
+            }
+
+            if (shouldSend) {
+                try {
+                    sendHeartbeat();
+                } catch (std::exception const &e) {
+                    ELOG_WARNING(log_, OPAMP, "Unable to send heartbeat {}", e.what());
+                }
             }
         }
     }
@@ -137,7 +172,8 @@ private:
     std::shared_ptr<opentelemetry::php::ConfigurationStorage> config_;
     std::shared_ptr<opentelemetry::php::transport::HttpTransportAsyncInterface> transport_;
     boost::uuids::uuid agentUid_{boost::uuids::random_generator()()};
-    std::atomic<std::chrono::seconds> heartbeatInterval_ = 30s;
+    std::atomic<std::chrono::milliseconds> heartbeatInterval_{std::chrono::milliseconds{30000}};
+    std::atomic<std::chrono::milliseconds> pollingInterval_{std::chrono::milliseconds{30000}};
 
     std::mutex configAccessMutex_;
     std::string currentConfigHash_;

--- a/prod/native/libcommon/test/transport/OpAmpTest.cpp
+++ b/prod/native/libcommon/test/transport/OpAmpTest.cpp
@@ -1,0 +1,268 @@
+#include "transport/OpAmp.h"
+#include "Logger.h"
+#include "ConfigurationStorage.h"
+#include "ResourceDetector.h"
+#include "PhpBridgeInterface.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace std::chrono_literals;
+using namespace std::literals;
+
+namespace opentelemetry::php::transport {
+
+class MockHttpTransportAsync : public HttpTransportAsyncInterface {
+public:
+    MOCK_METHOD(void, initializeConnection, (std::string, std::size_t, std::string, enpointHeaders_t const &, std::chrono::milliseconds, std::size_t, std::chrono::milliseconds, HttpEndpointSSLOptions), (override));
+    MOCK_METHOD(void, enqueue, (std::size_t, std::span<std::byte>, responseCallback_t), (override));
+    MOCK_METHOD(void, updateRetryDelay, (size_t, std::chrono::milliseconds), (override));
+};
+
+class MockPhpBridge : public opentelemetry::php::PhpBridgeInterface {
+public:
+    MOCK_METHOD(bool, callInferredSpans, (std::chrono::milliseconds), (const, override));
+    MOCK_METHOD(bool, callPHPSideEntryPoint, (LogLevel, std::chrono::time_point<std::chrono::system_clock>), (const, override));
+    MOCK_METHOD(bool, callPHPSideExitPoint, (), (const, override));
+    MOCK_METHOD(bool, callPHPSideErrorHandler, (int, std::string_view, uint32_t, std::string_view), (const, override));
+    MOCK_METHOD(void, enableScopedNamespaces, (bool), (override));
+    MOCK_METHOD(std::vector<phpExtensionInfo_t>, getExtensionList, (), (const, override));
+    MOCK_METHOD(std::string, getPhpInfo, (), (const, override));
+    MOCK_METHOD(std::string_view, getPhpSapiName, (), (const, override));
+    MOCK_METHOD(std::optional<std::string_view>, getCurrentExceptionMessage, (), (const, override));
+    MOCK_METHOD(void, compileAndExecuteFile, (std::string_view), (const, override));
+    MOCK_METHOD(void, enableAccessToServerGlobal, (), (const, override));
+    MOCK_METHOD(bool, detectOpcachePreload, (), (const, override));
+    MOCK_METHOD(bool, isScriptRestricedByOpcacheAPI, (), (const, override));
+    MOCK_METHOD(bool, detectOpcacheRestartPending, (), (const, override));
+    MOCK_METHOD(bool, isOpcacheEnabled, (), (const, override));
+    MOCK_METHOD(void, getCompiledFiles, (std::function<void(std::string_view)>), (const, override));
+    MOCK_METHOD((std::pair<std::size_t, std::size_t>), getNewlyCompiledFiles, (std::function<void(std::string_view)>, std::size_t, std::size_t), (const, override));
+    MOCK_METHOD((std::pair<int, int>), getPhpVersionMajorMinor, (), (const, override));
+    MOCK_METHOD(std::string, phpUname, (char), (const, override));
+};
+
+class OpAmpTest : public ::testing::Test {
+public:
+    OpAmpTest() {
+        if (std::getenv("OTEL_PHP_DEBUG_LOG_TESTS")) {
+            auto serr = std::make_shared<opentelemetry::php::LoggerSinkStdErr>();
+            serr->setLevel(logLevel_trace);
+            reinterpret_cast<opentelemetry::php::Logger *>(log_.get())->attachSink(serr);
+        }
+    }
+
+protected:
+    std::shared_ptr<opentelemetry::php::LoggerInterface> log_ = std::make_shared<opentelemetry::php::Logger>(std::vector<std::shared_ptr<opentelemetry::php::LoggerSinkInterface>>());
+    std::shared_ptr<MockHttpTransportAsync> transport_ = std::make_shared<MockHttpTransportAsync>();
+
+    std::shared_ptr<ConfigurationStorage> makeConfig(std::function<bool(ConfigurationSnapshot &)> updater = [](ConfigurationSnapshot &) { return false; }) {
+        return std::make_shared<ConfigurationStorage>(updater);
+    }
+
+    std::shared_ptr<OpAmp> createOpAmp(std::shared_ptr<ConfigurationStorage> config = nullptr, std::shared_ptr<opentelemetry::php::ResourceDetector> resourceDetector = nullptr) {
+        if (!config) {
+            config = makeConfig();
+        }
+        return std::make_shared<OpAmp>(log_, config, transport_, resourceDetector);
+    }
+
+    std::shared_ptr<opentelemetry::php::ResourceDetector> makeResourceDetector() {
+        auto bridge = std::make_shared<MockPhpBridge>();
+        EXPECT_CALL(*bridge, getPhpVersionMajorMinor()).WillRepeatedly(::testing::Return(std::make_pair(8, 3)));
+        EXPECT_CALL(*bridge, phpUname(::testing::_)).WillRepeatedly(::testing::Return("Linux"));
+        return std::make_shared<opentelemetry::php::ResourceDetector>(bridge);
+    }
+};
+
+TEST_F(OpAmpTest, DefaultIntervals) {
+    auto opamp = createOpAmp();
+
+    // Zero values should be ignored - no crash, no update
+    opamp->updateHeartbeatInterval(0ms);
+    opamp->updatePollingInterval(0ms);
+}
+
+TEST_F(OpAmpTest, UpdateHeartbeatInterval) {
+    auto opamp = createOpAmp();
+
+    opamp->updateHeartbeatInterval(5000ms);
+
+    // Sub-second values should also be accepted
+    opamp->updateHeartbeatInterval(500ms);
+}
+
+TEST_F(OpAmpTest, UpdatePollingInterval) {
+    auto opamp = createOpAmp();
+
+    opamp->updatePollingInterval(10000ms);
+
+    // Sub-second values should be accepted
+    opamp->updatePollingInterval(250ms);
+}
+
+TEST_F(OpAmpTest, ZeroIntervalIgnored) {
+    auto opamp = createOpAmp();
+
+    opamp->updateHeartbeatInterval(0ms);
+    opamp->updatePollingInterval(0ms);
+
+    opamp->updateHeartbeatInterval(std::chrono::milliseconds(-1));
+    opamp->updatePollingInterval(std::chrono::milliseconds(-1));
+}
+
+TEST_F(OpAmpTest, ConfigWatcherNotification) {
+    auto opamp = createOpAmp();
+
+    int notificationCount = 0;
+    OpAmp::configFiles_t receivedConfig;
+
+    auto connection = opamp->addConfigUpdateWatcher([&](OpAmp::configFiles_t const &cfg) {
+        notificationCount++;
+        receivedConfig = cfg;
+    });
+
+    auto cfg = opamp->getConfiguration();
+    ASSERT_TRUE(cfg.empty());
+
+    opamp->removeConfigUpdateWatcher(connection);
+}
+
+TEST_F(OpAmpTest, RemoveAllConfigUpdateWatchers) {
+    auto opamp = createOpAmp();
+
+    int count1 = 0, count2 = 0;
+    opamp->addConfigUpdateWatcher([&](OpAmp::configFiles_t const &) { count1++; });
+    opamp->addConfigUpdateWatcher([&](OpAmp::configFiles_t const &) { count2++; });
+
+    opamp->removeAllConfigUpdateWatchers();
+}
+
+TEST_F(OpAmpTest, EmptyEndpointDoesNotStartThread) {
+    auto opamp = createOpAmp();
+
+    EXPECT_CALL(*transport_, initializeConnection(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*transport_, enqueue(::testing::_, ::testing::_, ::testing::_)).Times(0);
+
+    opamp->startCommunication();
+}
+
+TEST_F(OpAmpTest, DestructorShutsDownCleanly) {
+    {
+        auto opamp = createOpAmp();
+    }
+}
+
+TEST_F(OpAmpTest, MultipleIntervalUpdates) {
+    auto opamp = createOpAmp();
+
+    for (int i = 1; i <= 10; i++) {
+        opamp->updateHeartbeatInterval(std::chrono::milliseconds(i * 100));
+        opamp->updatePollingInterval(std::chrono::milliseconds(i * 50));
+    }
+}
+
+TEST_F(OpAmpTest, HeartbeatSentAtIntervals) {
+    // Configure with non-empty endpoint and short intervals
+    auto config = makeConfig([](ConfigurationSnapshot &cfg) {
+        cfg.opamp_endpoint = "http://localhost:4320";
+        cfg.opamp_heartbeat_interval = 50ms;
+        cfg.opamp_polling_interval = 50ms;
+        return true;
+    });
+    config->update();
+
+    auto resourceDetector = makeResourceDetector();
+    auto opamp = createOpAmp(config, resourceDetector);
+
+    std::atomic_int enqueueCount = 0;
+
+    // Allow any number of enqueue calls, count them
+    EXPECT_CALL(*transport_, initializeConnection(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+    EXPECT_CALL(*transport_, enqueue(::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly([&enqueueCount](std::size_t, std::span<std::byte>, MockHttpTransportAsync::responseCallback_t) {
+            enqueueCount++;
+        });
+
+    opamp->startCommunication();
+
+    // Wait for heartbeat thread to send a few heartbeats
+    // With 50ms interval, in 300ms we expect at least 4-5 sends (1 initial + heartbeats)
+    std::this_thread::sleep_for(300ms);
+
+    auto count = enqueueCount.load();
+    // 1 initial + at least 4 heartbeats at 50ms intervals over 300ms
+    ASSERT_GE(count, 5) << "Expected at least 5 enqueue calls (1 initial + 4 heartbeats), got " << count;
+}
+
+TEST_F(OpAmpTest, HeartbeatRespectsUpdatedInterval) {
+    auto config = makeConfig([](ConfigurationSnapshot &cfg) {
+        cfg.opamp_endpoint = "http://localhost:4320";
+        cfg.opamp_heartbeat_interval = 50ms;
+        cfg.opamp_polling_interval = 50ms;
+        return true;
+    });
+    config->update();
+
+    auto resourceDetector = makeResourceDetector();
+    auto opamp = createOpAmp(config, resourceDetector);
+
+    std::atomic_int enqueueCount = 0;
+
+    EXPECT_CALL(*transport_, initializeConnection(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+    EXPECT_CALL(*transport_, enqueue(::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly([&enqueueCount](std::size_t, std::span<std::byte>, MockHttpTransportAsync::responseCallback_t) {
+            enqueueCount++;
+        });
+
+    opamp->startCommunication();
+
+    // Let it run with fast intervals
+    std::this_thread::sleep_for(200ms);
+    auto countFast = enqueueCount.load();
+
+    // Now slow it down significantly
+    opamp->updateHeartbeatInterval(5000ms);
+    opamp->updatePollingInterval(5000ms);
+
+    enqueueCount = 0;
+    std::this_thread::sleep_for(200ms);
+    auto countSlow = enqueueCount.load();
+
+    // Fast phase should have many more calls than slow phase
+    ASSERT_GE(countFast, 3) << "Fast phase should have at least 3 sends";
+    ASSERT_LE(countSlow, 1) << "Slow phase (5s interval) should have at most 1 send in 200ms, got " << countSlow;
+}
+
+TEST_F(OpAmpTest, SeparateHeartbeatAndPollingIntervals) {
+    auto config = makeConfig([](ConfigurationSnapshot &cfg) {
+        cfg.opamp_endpoint = "http://localhost:4320";
+        cfg.opamp_heartbeat_interval = 2000ms;  // slow heartbeat
+        cfg.opamp_polling_interval = 50ms;       // fast polling
+        return true;
+    });
+    config->update();
+
+    auto resourceDetector = makeResourceDetector();
+    auto opamp = createOpAmp(config, resourceDetector);
+
+    std::atomic_int enqueueCount = 0;
+
+    EXPECT_CALL(*transport_, initializeConnection(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1);
+    EXPECT_CALL(*transport_, enqueue(::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly([&enqueueCount](std::size_t, std::span<std::byte>, MockHttpTransportAsync::responseCallback_t) {
+            enqueueCount++;
+        });
+
+    opamp->startCommunication();
+
+    // With polling at 50ms and heartbeat at 2000ms, over 300ms
+    // we should see sends driven by the fast polling interval
+    std::this_thread::sleep_for(300ms);
+
+    auto count = enqueueCount.load();
+    // 1 initial + at least 4 from polling (heartbeat hasn't fired yet at 2000ms)
+    ASSERT_GE(count, 5) << "Polling at 50ms should drive sends even with slow heartbeat, got " << count;
+}
+
+} // namespace opentelemetry::php::transport

--- a/prod/php/OpenTelemetry/Distro/PhpPartFacade.php
+++ b/prod/php/OpenTelemetry/Distro/PhpPartFacade.php
@@ -120,12 +120,6 @@ final class PhpPartFacade
              * @noinspection PhpUnnecessaryFullyQualifiedNameInspection
              */
             if (\OpenTelemetry\Distro\get_config_option_by_name('inferred_spans_enabled')) {
-                self::logDebug(__LINE__, __FUNCTION__, 'Inferred spans is enabled, creating InferredSpans instance with config options', [
-                    'inferred_spans_reduction_enabled' => \OpenTelemetry\Distro\get_config_option_by_name('inferred_spans_reduction_enabled'),
-                    'inferred_spans_stacktrace_enabled' => \OpenTelemetry\Distro\get_config_option_by_name('inferred_spans_stacktrace_enabled'),
-                    'inferred_spans_min_duration' => \OpenTelemetry\Distro\get_config_option_by_name('inferred_spans_min_duration'),
-                ]);
-
                 /** @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
                 self::$singletonInstance->inferredSpans = new InferredSpans(
                     (bool)\OpenTelemetry\Distro\get_config_option_by_name('inferred_spans_reduction_enabled'),

--- a/prod/php/OpenTelemetry/Distro/PhpPartFacade.php
+++ b/prod/php/OpenTelemetry/Distro/PhpPartFacade.php
@@ -120,6 +120,12 @@ final class PhpPartFacade
              * @noinspection PhpUnnecessaryFullyQualifiedNameInspection
              */
             if (\OpenTelemetry\Distro\get_config_option_by_name('inferred_spans_enabled')) {
+                self::logDebug(__LINE__, __FUNCTION__, 'Inferred spans is enabled, creating InferredSpans instance with config options', [
+                    'inferred_spans_reduction_enabled' => \OpenTelemetry\Distro\get_config_option_by_name('inferred_spans_reduction_enabled'),
+                    'inferred_spans_stacktrace_enabled' => \OpenTelemetry\Distro\get_config_option_by_name('inferred_spans_stacktrace_enabled'),
+                    'inferred_spans_min_duration' => \OpenTelemetry\Distro\get_config_option_by_name('inferred_spans_min_duration'),
+                ]);
+
                 /** @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
                 self::$singletonInstance->inferredSpans = new InferredSpans(
                     (bool)\OpenTelemetry\Distro\get_config_option_by_name('inferred_spans_reduction_enabled'),


### PR DESCRIPTION
This PR improves OpAMP remote configuration handling with several fixes and enhancements.

### Separate heartbeat and polling intervals
- Added `OTEL_PHP_OPAMP_POLLING_INTERVAL` config option, independent from heartbeat
- Implemented dual-timer loop in `opAmpHeartbeatTask()` - heartbeat and polling fire on independent schedules

### Fix inferred spans via remote config
- Zend VM hooks (`zend_interrupt_function`, `zend_execute_internal`) were only installed at MINIT - added idempotent `Hooking::enableInferredSpansHooks()` called from RINIT so hooks are installed when inferred spans are enabled via remote config after startup

### Extend VendorCustomizationsInterface
- Added `setLogger()` and `getAdditionalResourceAttributes()` virtual methods
- Added `ResourceDetector::addAttributes()` for vendor resource injection
- Coordinator injects vendor resource attributes before OpAmp starts

### Tests
- Added `OpAmpTest`
