### PR TITLE
PostgreSQL smoke component test (#87)

### DIFF
--- a/tests/OTelDistroTests/ComponentTests/PgSqlAutoInstrumentationTest.php
+++ b/tests/OTelDistroTests/ComponentTests/PgSqlAutoInstrumentationTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OTelDistroTests\ComponentTests;
+
+use OTelDistroTests\ComponentTests\Util\AppCodeContextUtil;
+use OTelDistroTests\ComponentTests\Util\AppCodeHostParams;
+use OTelDistroTests\ComponentTests\Util\AppCodeRequestParams;
+use OTelDistroTests\ComponentTests\Util\AppCodeTarget;
+use OTelDistroTests\ComponentTests\Util\ComponentTestCaseBase;
+use OTelDistroTests\ComponentTests\Util\DbAutoInstrumentationUtilForTests;
+use OTelDistroTests\ComponentTests\Util\PgSql\PgSqlDbSpanDataExpectationsBuilder;
+use OTelDistroTests\ComponentTests\Util\SpanExpectations;
+use OTelDistroTests\ComponentTests\Util\SpanSequenceExpectations;
+use OTelDistroTests\ComponentTests\Util\WaitForOTelSignalCounts;
+use OTelDistroTests\Util\AmbientContextForTests;
+use OTelDistroTests\Util\AssertEx;
+use OTelDistroTests\Util\Config\OptionForProdName;
+use OTelDistroTests\Util\DataProviderForTestBuilder;
+use OTelDistroTests\Util\DebugContext;
+use OTelDistroTests\Util\Log\LoggableToString;
+use OTelDistroTests\Util\MixedMap;
+use OpenTelemetry\SemConv\TraceAttributes;
+
+/**
+ * @group smoke
+ * @group requires_external_services
+ */
+final class PgSqlAutoInstrumentationTest extends ComponentTestCaseBase
+{
+    private const AUTO_INSTRUMENTATION_NAME = 'postgresql';
+    private const IS_AUTO_INSTRUMENTATION_ENABLED_KEY = 'is_auto_instrumentation_enabled';
+
+    private const MESSAGES
+        = [
+            'Just testing...'    => 1,
+            'More testing...'    => 22,
+            'SQLite3 is cool...' => 333,
+        ];
+
+    private const CREATE_TABLE_SQL
+        = /** @lang text */
+        'CREATE TABLE IF NOT EXISTS messages (
+            id SERIAL PRIMARY KEY,
+            text TEXT,
+            time INTEGER
+        )';
+
+    private const DROP_TABLE_SQL
+        = /** @lang text */
+        'DROP TABLE IF EXISTS messages';
+
+    private const INSERT_SQL
+        = /** @lang text */
+        'INSERT INTO messages (text, time) VALUES ($1, $2)';
+
+    private const SELECT_SQL
+        = /** @lang text */
+        'SELECT * FROM messages';
+
+    private static bool $verifiedPrerequisites = false;
+
+    private static function assertExtensionLoaded(): void
+    {
+        $pgsqlExtensionName = 'pgsql';
+        self::assertTrue(extension_loaded($pgsqlExtensionName), 'Extension ' . $pgsqlExtensionName . ' is not loaded');
+    }
+
+    private static function buildConnectionString(string $host, int $port, string $user, string $password, ?string $dbName): string
+    {
+        $connStr = "host={$host} port={$port} user={$user} password={$password}";
+        if ($dbName !== null) {
+            $connStr .= " dbname={$dbName}";
+        }
+        return $connStr;
+    }
+
+    private static function assertPrerequisites(): void
+    {
+        DebugContext::getCurrentScope(/* out */ $dbgCtx);
+
+        self::assertExtensionLoaded();
+
+        $config = AmbientContextForTests::testConfig();
+        self::assertNotNull($config->postgresqlHost);
+        self::assertNotNull($config->postgresqlPort);
+        self::assertNotNull($config->postgresqlUser);
+        self::assertNotNull($config->postgresqlPassword);
+        self::assertNotNull($config->postgresqlDb);
+
+        $connStr = self::buildConnectionString(
+            AssertEx::notNull($config->postgresqlHost),
+            AssertEx::notNull($config->postgresqlPort),
+            AssertEx::notNull($config->postgresqlUser),
+            AssertEx::notNull($config->postgresqlPassword),
+            AssertEx::notNull($config->postgresqlDb)
+        );
+        $conn = pg_connect($connStr);
+        self::assertNotFalse($conn, 'Failed to connect to PostgreSQL');
+        pg_close($conn);
+    }
+
+    /**
+     * @return iterable<string, array{MixedMap}>
+     */
+    public static function dataProviderForTestAutoInstrumentation(): iterable
+    {
+        if (!AmbientContextForTests::testConfig()->doesRequireExternalServices()) {
+            return ['dummy test args' => [new MixedMap()]];
+        }
+
+        return self::adaptDataProviderForTestBuilderToSmokeToDescToMixedMap(
+            (new DataProviderForTestBuilder())
+                ->addBoolKeyedDimensionAllValuesCombinable(self::IS_AUTO_INSTRUMENTATION_ENABLED_KEY)
+                ->addGeneratorOnlyFirstValueCombinable(DbAutoInstrumentationUtilForTests::wrapTxRelatedArgsDataProviderGenerator())
+        );
+    }
+
+    public static function appCodeForTestAutoInstrumentation(MixedMap $appCodeArgs): void
+    {
+        DebugContext::getCurrentScope(/* out */ $dbgCtx);
+
+        self::assertExtensionLoaded();
+
+        $isAutoInstrumentationEnabled = $appCodeArgs->getBool(self::IS_AUTO_INSTRUMENTATION_ENABLED_KEY);
+        if ($isAutoInstrumentationEnabled) {
+            $pgSqlInstrumentationFqClassName = AppCodeContextUtil::adaptClassNameRawStringToScoping('OpenTelemetry\\Contrib\\Instrumentation\\PostgreSql\\PostgreSqlInstrumentation');
+            self::assertTrue(class_exists($pgSqlInstrumentationFqClassName, autoload: false));
+            AssertEx::sameConstValues(constant($pgSqlInstrumentationFqClassName . '::NAME'), self::AUTO_INSTRUMENTATION_NAME);
+        }
+
+        $wrapInTx = $appCodeArgs->getBool(DbAutoInstrumentationUtilForTests::WRAP_IN_TX_KEY);
+        $rollback = $appCodeArgs->getBool(DbAutoInstrumentationUtilForTests::SHOULD_ROLLBACK_KEY);
+
+        $host = $appCodeArgs->getString(DbAutoInstrumentationUtilForTests::HOST_KEY);
+        $port = $appCodeArgs->getInt(DbAutoInstrumentationUtilForTests::PORT_KEY);
+        $user = $appCodeArgs->getString(DbAutoInstrumentationUtilForTests::USER_KEY);
+        $password = $appCodeArgs->getString(DbAutoInstrumentationUtilForTests::PASSWORD_KEY);
+        $dbName = $appCodeArgs->getString(DbAutoInstrumentationUtilForTests::DB_NAME_KEY);
+
+        $connStr = self::buildConnectionString($host, $port, $user, $password, $dbName);
+        $conn = pg_connect($connStr);
+        self::assertNotFalse($conn, 'Failed to connect to PostgreSQL');
+
+        // Drop table first to reset state, then create
+        $result = pg_query($conn, self::DROP_TABLE_SQL);
+        self::assertNotFalse($result);
+        $result = pg_query($conn, self::CREATE_TABLE_SQL);
+        self::assertNotFalse($result);
+
+        if ($wrapInTx) {
+            $result = pg_query($conn, 'BEGIN');
+            self::assertNotFalse($result);
+        }
+
+        $stmtResult = pg_prepare($conn, 'insert_msg', self::INSERT_SQL);
+        self::assertNotFalse($stmtResult);
+        foreach (self::MESSAGES as $msgText => $msgTime) {
+            $execResult = pg_execute($conn, 'insert_msg', [$msgText, $msgTime]);
+            self::assertNotFalse($execResult);
+        }
+
+        $queryResult = pg_query($conn, self::SELECT_SQL);
+        self::assertNotFalse($queryResult);
+        $rowCount = pg_num_rows($queryResult);
+        self::assertSame(count(self::MESSAGES), $rowCount);
+        while (($row = pg_fetch_assoc($queryResult)) !== false) {
+            $dbgCtx = LoggableToString::convert(['$row' => $row]);
+            $msgText = $row['text'];
+            self::assertIsString($msgText);
+            self::assertArrayHasKey($msgText, self::MESSAGES, $dbgCtx);
+            self::assertEquals(self::MESSAGES[$msgText], (int)$row['time'], $dbgCtx);
+        }
+
+        if ($wrapInTx) {
+            $result = pg_query($conn, $rollback ? 'ROLLBACK' : 'COMMIT');
+            self::assertNotFalse($result);
+        }
+
+        // Cleanup
+        $result = pg_query($conn, self::DROP_TABLE_SQL);
+        self::assertNotFalse($result);
+
+        pg_close($conn);
+    }
+
+    private function implTestAutoInstrumentation(MixedMap $testArgs): void
+    {
+        DebugContext::getCurrentScope(/* out */ $dbgCtx);
+
+        self::assertNotEmpty(self::MESSAGES); // @phpstan-ignore staticMethod.alreadyNarrowedType
+
+        $logger = self::getLoggerStatic(__NAMESPACE__, __CLASS__, __FILE__);
+        ($loggerProxy = $logger->ifTraceLevelEnabled(__LINE__, __FUNCTION__))
+        && $loggerProxy->log('Entered', ['$testArgs' => $testArgs]);
+
+        $isAutoInstrumentationEnabled = $testArgs->getBool(self::IS_AUTO_INSTRUMENTATION_ENABLED_KEY);
+        $wrapInTx = $testArgs->getBool(DbAutoInstrumentationUtilForTests::WRAP_IN_TX_KEY);
+        $rollback = $testArgs->getBool(DbAutoInstrumentationUtilForTests::SHOULD_ROLLBACK_KEY);
+
+        $dbName = AssertEx::notNull(AmbientContextForTests::testConfig()->postgresqlDb);
+
+        /** @var SpanExpectations[] $expectedDbSpans */
+        $expectedDbSpans = [];
+        if ($isAutoInstrumentationEnabled) {
+            $expectationsBuilder = (new PgSqlDbSpanDataExpectationsBuilder())
+                ->serverAddress(AssertEx::notNull(AmbientContextForTests::testConfig()->postgresqlHost))
+                ->dbNamespace($dbName);
+
+            // pg_connect
+            $expectedDbSpans[] = $expectationsBuilder->buildForPgFunction('pg_connect');
+
+            // pg_query: DROP TABLE IF EXISTS
+            $expectedDbSpans[] = $expectationsBuilder->buildForPgFunction('pg_query', self::DROP_TABLE_SQL);
+
+            // pg_query: CREATE TABLE
+            $expectedDbSpans[] = $expectationsBuilder->buildForPgFunction('pg_query', self::CREATE_TABLE_SQL);
+
+            if ($wrapInTx) {
+                // pg_query: BEGIN
+                $expectedDbSpans[] = $expectationsBuilder->buildForPgFunction('pg_query', 'BEGIN');
+            }
+
+            // pg_prepare: INSERT
+            $expectedDbSpans[] = $expectationsBuilder->buildForPgFunction('pg_prepare', self::INSERT_SQL);
+
+            // pg_execute × N
+            foreach (self::MESSAGES as $ignored) {
+                $expectedDbSpans[] = $expectationsBuilder->buildForPgFunction('pg_execute', self::INSERT_SQL);
+            }
+
+            // pg_query: SELECT
+            $expectedDbSpans[] = $expectationsBuilder->buildForPgFunction('pg_query', self::SELECT_SQL);
+
+            if ($wrapInTx) {
+                // pg_query: COMMIT/ROLLBACK
+                $expectedDbSpans[] = $expectationsBuilder->buildForPgFunction('pg_query', $rollback ? 'ROLLBACK' : 'COMMIT');
+            }
+
+            // pg_query: DROP TABLE (cleanup)
+            $expectedDbSpans[] = $expectationsBuilder->buildForPgFunction('pg_query', self::DROP_TABLE_SQL);
+        }
+        $dbgCtx->add(compact('expectedDbSpans'));
+
+        $appCodeArgs = $testArgs->clone();
+        $appCodeArgs[DbAutoInstrumentationUtilForTests::HOST_KEY] = AmbientContextForTests::testConfig()->postgresqlHost;
+        $appCodeArgs[DbAutoInstrumentationUtilForTests::PORT_KEY] = AmbientContextForTests::testConfig()->postgresqlPort;
+        $appCodeArgs[DbAutoInstrumentationUtilForTests::USER_KEY] = AmbientContextForTests::testConfig()->postgresqlUser;
+        $appCodeArgs[DbAutoInstrumentationUtilForTests::PASSWORD_KEY] = AmbientContextForTests::testConfig()->postgresqlPassword;
+        $appCodeArgs[DbAutoInstrumentationUtilForTests::DB_NAME_KEY] = AmbientContextForTests::testConfig()->postgresqlDb;
+
+        $testCaseHandle = $this->getTestCaseHandle();
+        $appCodeHost = $testCaseHandle->ensureMainAppCodeHost(
+            function (AppCodeHostParams $appCodeParams) use ($isAutoInstrumentationEnabled): void {
+                if (!$isAutoInstrumentationEnabled) {
+                    $appCodeParams->setProdOptionIfNotNull(OptionForProdName::disabled_instrumentations, self::AUTO_INSTRUMENTATION_NAME);
+                }
+                self::disableTimingDependentFeatures($appCodeParams);
+            }
+        );
+        $appCodeHost->execAppCode(
+            AppCodeTarget::asRouted([__CLASS__, 'appCodeForTestAutoInstrumentation']),
+            function (AppCodeRequestParams $appCodeRequestParams) use ($appCodeArgs): void {
+                $appCodeRequestParams->setAppCodeArgs($appCodeArgs);
+            }
+        );
+
+        // +1 for automatic local root span
+        $agentBackendComms = $testCaseHandle->waitForEnoughAgentBackendComms(WaitForOTelSignalCounts::spans(1 + count($expectedDbSpans)));
+        $dbgCtx->add(compact('agentBackendComms'));
+
+        $actualDbSpans = [];
+        foreach ($agentBackendComms->spans() as $span) {
+            if ($span->attributes->keyExists(TraceAttributes::DB_SYSTEM_NAME)) {
+                $actualDbSpans[] = $span;
+            }
+        }
+        (new SpanSequenceExpectations($expectedDbSpans))->assertMatches($actualDbSpans);
+    }
+
+    /**
+     * @dataProvider dataProviderForTestAutoInstrumentation
+     */
+    public function testAutoInstrumentation(MixedMap $testArgs): void
+    {
+        if (!self::$verifiedPrerequisites) {
+            self::assertPrerequisites();
+            self::$verifiedPrerequisites = true;
+        }
+        self::runAndEscalateLogLevelOnFailure(
+            self::buildDbgDescForTestWithArgs(__CLASS__, __FUNCTION__, $testArgs),
+            function () use ($testArgs): void {
+                $this->implTestAutoInstrumentation($testArgs);
+            }
+        );
+    }
+}

--- a/tests/OTelDistroTests/ComponentTests/Util/PgSql/PgSqlDbSpanDataExpectationsBuilder.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/PgSql/PgSqlDbSpanDataExpectationsBuilder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OTelDistroTests\ComponentTests\Util\PgSql;
+
+use OTelDistroTests\ComponentTests\Util\DbSpanExpectationsBuilder;
+use OTelDistroTests\ComponentTests\Util\SpanExpectations;
+
+/**
+ * Code in this file is part of implementation internals and thus it is not covered by the backward compatibility.
+ *
+ * @internal
+ */
+final class PgSqlDbSpanDataExpectationsBuilder extends DbSpanExpectationsBuilder
+{
+    public const DB_SYSTEM_NAME = 'postgresql';
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->dbSystemName(self::DB_SYSTEM_NAME);
+    }
+
+    public function buildForPgFunction(string $funcName, ?string $dbQueryText = null): SpanExpectations
+    {
+        $builderClone = clone $this;
+        $builderClone->nameAndCodeAttributesUsingFuncName($funcName);
+        $builderClone->optionalDbQueryTextAndOperationName($dbQueryText);
+        return $builderClone->build();
+    }
+}

--- a/tests/OTelDistroTests/Util/Config/ConfigSnapshotForTests.php
+++ b/tests/OTelDistroTests/Util/Config/ConfigSnapshotForTests.php
@@ -50,6 +50,12 @@ final class ConfigSnapshotForTests implements LoggableInterface
     public readonly ?string $mysqlPassword; // @phpstan-ignore property.uninitializedReadonly
     public readonly ?string $mysqlDb; // @phpstan-ignore property.uninitializedReadonly
 
+    public readonly ?string $postgresqlHost; // @phpstan-ignore property.uninitializedReadonly
+    public readonly ?int $postgresqlPort; // @phpstan-ignore property.uninitializedReadonly
+    public readonly ?string $postgresqlUser; // @phpstan-ignore property.uninitializedReadonly
+    public readonly ?string $postgresqlPassword; // @phpstan-ignore property.uninitializedReadonly
+    public readonly ?string $postgresqlDb; // @phpstan-ignore property.uninitializedReadonly
+
     /**
      * @param array<string, mixed> $optNameToParsedValue
      */

--- a/tests/OTelDistroTests/Util/Config/OptionForTestsName.php
+++ b/tests/OTelDistroTests/Util/Config/OptionForTestsName.php
@@ -39,6 +39,12 @@ enum OptionForTestsName
     case mysql_password;
     case mysql_db;
 
+    case postgresql_host;
+    case postgresql_port;
+    case postgresql_user;
+    case postgresql_password;
+    case postgresql_db;
+
     public const ENV_VAR_NAME_PREFIX = 'OTEL_PHP_TESTS_';
 
     public function toEnvVarName(): string

--- a/tests/OTelDistroTests/Util/Config/OptionsForTestsMetadata.php
+++ b/tests/OTelDistroTests/Util/Config/OptionsForTestsMetadata.php
@@ -55,6 +55,12 @@ final class OptionsForTestsMetadata
             [OptionForTestsName::mysql_user, new NullableStringOptionMetadata()],
             [OptionForTestsName::mysql_password, new NullableStringOptionMetadata()],
             [OptionForTestsName::mysql_db, new NullableStringOptionMetadata()],
+
+            [OptionForTestsName::postgresql_host, new NullableStringOptionMetadata()],
+            [OptionForTestsName::postgresql_port, new NullableIntOptionMetadata(1, 65535)],
+            [OptionForTestsName::postgresql_user, new NullableStringOptionMetadata()],
+            [OptionForTestsName::postgresql_password, new NullableStringOptionMetadata()],
+            [OptionForTestsName::postgresql_db, new NullableStringOptionMetadata()],
         ];
         $this->optionsNameValueMap = self::convertPairsToMap($optNameMetaPairs, OptionForTestsName::cases());
     }

--- a/tools/test/component/docker_compose_external_services.yml
+++ b/tools/test/component/docker_compose_external_services.yml
@@ -15,10 +15,26 @@ services:
         networks:
             - otel-php-distro-tests-component-network
 
+    otel-php-distro-tests-component-postgresql:
+        image: postgres:17.5
+        restart: always
+        environment:
+            - POSTGRES_DB=${OTEL_PHP_TESTS_POSTGRESQL_DB}
+            - POSTGRES_USER=${OTEL_PHP_TESTS_POSTGRESQL_USER}
+            - POSTGRES_PASSWORD=${OTEL_PHP_TESTS_POSTGRESQL_PASSWORD}
+        healthcheck:
+            test: [ "CMD-SHELL", "PGPASSWORD=${OTEL_PHP_TESTS_POSTGRESQL_PASSWORD} psql -U ${OTEL_PHP_TESTS_POSTGRESQL_USER} -d ${OTEL_PHP_TESTS_POSTGRESQL_DB} -h 127.0.0.1 -c 'SELECT 1'" ]
+            timeout: 5s
+            retries: 60
+        networks:
+            - otel-php-distro-tests-component-network
+
     otel-php-distro-tests-component-wait-for-all-services-to-start:
         image: busybox
         depends_on:
             otel-php-distro-tests-component-mysql:
+                condition: service_healthy
+            otel-php-distro-tests-component-postgresql:
                 condition: service_healthy
 
 networks:

--- a/tools/test/component/external_services_env_vars.sh
+++ b/tools/test/component/external_services_env_vars.sh
@@ -11,6 +11,12 @@ if [ -z "${OTEL_PHP_TESTS_EXTERNAL_SERVICES_ENV_VARS_ARE_SET+x}" ] || [ "${OTEL_
     export OTEL_PHP_TESTS_MYSQL_PASSWORD=otel-php-distro-tests-component-mysql-password
     export OTEL_PHP_TESTS_MYSQL_DB=OTEL_PHP_COMPONENT_TESTS_DB
 
+    export OTEL_PHP_TESTS_POSTGRESQL_HOST=otel-php-distro-tests-component-postgresql
+    export OTEL_PHP_TESTS_POSTGRESQL_PORT=5432
+    export OTEL_PHP_TESTS_POSTGRESQL_USER=otel_user
+    export OTEL_PHP_TESTS_POSTGRESQL_PASSWORD=otel_passwd
+    export OTEL_PHP_TESTS_POSTGRESQL_DB=otel_db
+
     export OTEL_PHP_TESTS_EXTERNAL_SERVICES_DOCKER_COMPOSE_CMD_PREFIX="docker compose -f ${repo_root_dir:?}/tools/test/component/docker_compose_external_services.yml"
 
     export OTEL_PHP_TESTS_EXTERNAL_SERVICES_ENV_VARS_ARE_SET=true


### PR DESCRIPTION
Adds an end-to-end component test for the bundled `opentelemetry-auto-postgresql` instrumentation, following the same pattern as `MySqliAutoInstrumentationTest`.

#### How to test

Build deb package and run:

```bash
OTEL_PHP_TESTS_FILTER="PgSqlAutoInstrumentationTest" \
  ./tools/test/component/test_packages_one_matrix_row_in_docker.sh \
  --matrix_row '8.5,deb,cli,with_ext_svc,prod_log_level_syslog=TRACE' \
  --packages_dir "$(pwd)/build/packages/" \
  --logs_dir '/tmp/logs'
```
