### PR TITLE
feat: add earlySetup to register OTLP transport before SDK initialization

### DIFF
--- a/prod/php/OpenTelemetry/Distro/PhpPartFacade.php
+++ b/prod/php/OpenTelemetry/Distro/PhpPartFacade.php
@@ -237,6 +237,12 @@ final class PhpPartFacade
         $logDebug?->with(__LINE__, 'Finished successfully');
     }
 
+    public static function earlySetup(): void
+    {
+        self::registerNativeOtlpSerializer();
+        self::registerAsyncTransportFactory();
+    }
+
     private static function registerAsyncTransportFactory(): void
     {
         /**
@@ -268,7 +274,7 @@ final class PhpPartFacade
             // Load classes such as \OpenTelemetry\Contrib\Otlp\SpanExporter to shadow the ones in SDK
             $otelOtlpDir = ProdPhpDir::$fullPath . DIRECTORY_SEPARATOR . 'OpenTelemetry' . DIRECTORY_SEPARATOR . 'Contrib' . DIRECTORY_SEPARATOR . 'Otlp';
             foreach (['SpanExporter', 'LogsExporter', 'MetricExporter'] as $exporter) {
-                require $otelOtlpDir . DIRECTORY_SEPARATOR . $exporter . '.php';
+                require_once $otelOtlpDir . DIRECTORY_SEPARATOR . $exporter . '.php';
             }
         }
     }

--- a/prod/php/OpenTelemetry/Distro/earlySetup.php
+++ b/prod/php/OpenTelemetry/Distro/earlySetup.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+\OpenTelemetry\Distro\PhpPartFacade::earlySetup();

--- a/tools/build/fix_scoped_composer_autoload.php
+++ b/tools/build/fix_scoped_composer_autoload.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Applies four post-scoping fixes to a php-scoper-generated vendor directory:
  *
@@ -27,6 +25,8 @@ declare(strict_types=1);
  *
  * Usage: php tools/build/fix_scoped_composer_autoload.php <namespace_prefix> <vendor_dir>
  */
+
+declare(strict_types=1);
 
 if ($_SERVER['argc'] !== 3) {
     fwrite(STDERR, "Usage: php tools/build/fix_scoped_composer_autoload.php <namespace_prefix> <vendor_dir>\n");

--- a/tools/build/fix_scoped_composer_autoload.php
+++ b/tools/build/fix_scoped_composer_autoload.php
@@ -2,6 +2,32 @@
 
 declare(strict_types=1);
 
+/**
+ * Applies four post-scoping fixes to a php-scoper-generated vendor directory:
+ *
+ * 1. autoload_real.php — rewrites ClassLoader references to use the scoped namespace prefix
+ *    so that the scoped and application Composer autoloaders do not collide.
+ *
+ * 2. autoload_real.php — rewrites PSR-4 prefixes and classmap after autoload_static.php is
+ *    loaded, prepending the scoped namespace prefix to all entries.
+ *
+ * 3. autoload_files.php / autoload_static.php — prepends earlySetup.php as the first entry
+ *    in the Composer files loop so that PhpPartFacade::earlySetup() runs before sdk/_autoload.php
+ *    and any instrumentation _register.php files. This prevents race conditions when
+ *    instrumentations (e.g. tbachert/otel-instrumentation-runtime-metrics) call
+ *    Globals::meterProvider() eagerly inside register() and trigger premature SDK initialization.
+ *
+ * 4. autoload_files.php / autoload_static.php — rehashes file identifiers (md5 keys) with the
+ *    scoped prefix so that they do not collide with the application's own Composer autoloader
+ *    ($GLOBALS['__composer_autoload_files'] collision prevention).
+ *
+ * 5. autoload_files.php / autoload_static.php — reorders exporter-otlp/_register.php before
+ *    sdk/_autoload.php so that the OTLP exporter factory is registered before the SDK initializer
+ *    runs, preventing "Span exporter factory not defined for: otlp" errors.
+ *
+ * Usage: php tools/build/fix_scoped_composer_autoload.php <namespace_prefix> <vendor_dir>
+ */
+
 if ($_SERVER['argc'] !== 3) {
     fwrite(STDERR, "Usage: php tools/build/fix_scoped_composer_autoload.php <namespace_prefix> <vendor_dir>\n");
     exit(1);
@@ -17,7 +43,8 @@ if (!preg_match('/^[A-Za-z_][A-Za-z0-9_\\\\]*$/', $prefix)) {
     exit(1);
 }
 
-$autoloadRealPath = rtrim($vendorDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR . 'autoload_real.php';
+$composerDir = rtrim($vendorDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR;
+$autoloadRealPath = $composerDir . 'autoload_real.php';
 if (!is_file($autoloadRealPath)) {
     fwrite(STDERR, "File does not exist: $autoloadRealPath\n");
     exit(1);
@@ -49,6 +76,8 @@ $replaceCallbackOrFail = static function (string $pattern, callable $callback, s
     return $result;
 };
 
+// --- Fix 1: Rewrite ClassLoader references to use the scoped namespace ---
+
 $prefixedClassLoader = $prefix . '\\\\Composer\\\\Autoload\\\\ClassLoader';
 $content = $replaceCallbackOrFail(
     "/if \\\('[^']*ClassLoader' === \\\$class\\\) \\\{/",
@@ -69,6 +98,8 @@ $content = $replaceOrFail(
     $content,
     "Failed to patch autoload unregister callback in $autoloadRealPath\n"
 );
+
+// --- Fix 2: Rewrite PSR-4 prefixes and classmap with the scoped namespace prefix ---
 
 // Load excluded namespaces from php-scoper.inc.php - single source of truth.
 // We use a closure to isolate the require's variable scope so that $prefix, $extensionFunctionFqcns
@@ -161,11 +192,60 @@ if (file_put_contents($autoloadRealPath, $content) === false) {
 
 fwrite(STDOUT, "Patched scoped Composer autoloader: $autoloadRealPath\n");
 
-// Rehash file identifiers in autoload_files.php and autoload_static.php
-// to avoid collisions with the monitored application's own Composer autoloader.
+// --- Fix 3: Prepend earlySetup.php as the first entry in the files autoload loop ---
+
+$prependEarlySetupEntry = static function (
+    string $filePath,
+    string $entry,
+    string $insertAfter
+): void {
+    if (!is_file($filePath)) {
+        fwrite(STDERR, "File does not exist (skipping early setup prepend): $filePath\n");
+        return;
+    }
+
+    $content = file_get_contents($filePath);
+    if (!is_string($content)) {
+        fwrite(STDERR, "Failed to read: $filePath\n");
+        exit(1);
+    }
+
+    if (str_contains($content, 'earlySetup.php')) {
+        fwrite(STDOUT, "Early setup entry already present in: $filePath\n");
+        return;
+    }
+
+    $newContent = str_replace($insertAfter, $insertAfter . $entry, $content);
+    if ($newContent === $content) {
+        fwrite(STDERR, "Failed to find insertion point '$insertAfter' in: $filePath\n");
+        exit(1);
+    }
+
+    if (file_put_contents($filePath, $newContent) === false) {
+        fwrite(STDERR, "Failed to write: $filePath\n");
+        exit(1);
+    }
+
+    fwrite(STDOUT, "Prepended early setup entry in: $filePath\n");
+};
+
+$earlySetupHash = md5('otel-distro:OpenTelemetry/Distro/earlySetup.php');
+$prependEarlySetupEntry(
+    $composerDir . 'autoload_files.php',
+    "'" . $earlySetupHash . "' => \$baseDir . '/OpenTelemetry/Distro/earlySetup.php', ",
+    'return array('
+);
+$prependEarlySetupEntry(
+    $composerDir . 'autoload_static.php',
+    "'" . $earlySetupHash . "' => __DIR__ . '/../../OpenTelemetry/Distro/earlySetup.php', ",
+    'public static $files = array('
+);
+
+// --- Fix 4: Rehash file identifiers to avoid collision with the application's autoloader ---
 // Composer tracks loaded files via $GLOBALS['__composer_autoload_files'][$hash].
-// Without rehashing, both the scoped distro vendor and the app vendor would use
-// identical hashes (same md5(packageName:relPath)), causing one side to skip loading.
+// Without rehashing, both the scoped distro vendor and the app vendor would use identical
+// hashes (same md5(packageName:relPath)), causing one side to silently skip loading.
+
 $rehashFileIdentifiers = static function (string $filePath) use ($prefix): void {
     if (!is_file($filePath)) {
         fwrite(STDERR, "File does not exist (skipping rehash): $filePath\n");
@@ -179,14 +259,11 @@ $rehashFileIdentifiers = static function (string $filePath) use ($prefix): void 
     }
 
     $replacedCount = 0;
-    $seenOriginalHashes = [];
     $newContent = preg_replace_callback(
         "/(?<='|\"|\\\$files = array\\()([a-f0-9]{32})(?=')/",
-        static function (array $match) use ($prefix, &$replacedCount, &$seenOriginalHashes): string {
-            $originalHash = $match[1];
-            $seenOriginalHashes[$originalHash] = true;
+        static function (array $match) use ($prefix, &$replacedCount): string {
             $replacedCount++;
-            return md5($prefix . ':' . $originalHash);
+            return md5($prefix . ':' . $match[1]);
         },
         $fileContent
     );
@@ -209,6 +286,96 @@ $rehashFileIdentifiers = static function (string $filePath) use ($prefix): void 
     fwrite(STDOUT, "Rehashed $replacedCount file identifier(s) in: $filePath\n");
 };
 
-$composerDir = rtrim($vendorDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'composer' . DIRECTORY_SEPARATOR;
 $rehashFileIdentifiers($composerDir . 'autoload_files.php');
 $rehashFileIdentifiers($composerDir . 'autoload_static.php');
+
+// --- Fix 5: Reorder exporter-otlp/_register.php before sdk/_autoload.php ---
+// sdk/_autoload.php registers a Globals initializer that, when triggered, initializes the SDK
+// and creates OTLP exporters. exporter-otlp/_register.php registers the OTLP exporter factory
+// used during that initialization. If sdk/_autoload.php runs first and an instrumentation
+// triggers early SDK initialization, the factory is not yet registered and initialization fails.
+
+$reorderAutoloadEntries = static function (string $filePath, string $pathToMove, string $insertBefore): void {
+    if (!is_file($filePath)) {
+        fwrite(STDERR, "File does not exist (skipping reorder): $filePath\n");
+        return;
+    }
+
+    $content = file_get_contents($filePath);
+    if (!is_string($content)) {
+        fwrite(STDERR, "Failed to read: $filePath\n");
+        exit(1);
+    }
+
+    $pathToMoveMarker = $pathToMove . "'";
+    $insertBeforeMarker = $insertBefore . "'";
+
+    $pathToMovePos = strpos($content, $pathToMoveMarker);
+    $insertBeforePos = strpos($content, $insertBeforeMarker);
+
+    if ($pathToMovePos === false || $insertBeforePos === false) {
+        fwrite(STDOUT, "Skipping reorder (markers not found) in: $filePath\n");
+        return;
+    }
+
+    if ($pathToMovePos < $insertBeforePos) {
+        fwrite(STDOUT, "No reorder needed in: $filePath\n");
+        return;
+    }
+
+    // Find the start of the entry by searching backwards for the ', ' separator
+    $sepPos = strrpos(substr($content, 0, $pathToMovePos), ", '");
+    if ($sepPos === false) {
+        fwrite(STDERR, "Cannot find entry boundary for '$pathToMove' in: $filePath\n");
+        exit(1);
+    }
+
+    $entryStart = $sepPos + 2; // skip ', ' to reach the opening quote of the hash
+    $entryToMove = substr($content, $entryStart, $pathToMovePos + strlen($pathToMoveMarker) - $entryStart);
+
+    $newContent = str_replace(', ' . $entryToMove, '', $content);
+    if ($newContent === $content) {
+        fwrite(STDERR, "Failed to remove '$pathToMove' entry from: $filePath\n");
+        exit(1);
+    }
+
+    $insertBeforePos2 = strpos($newContent, $insertBeforeMarker);
+    if ($insertBeforePos2 === false) {
+        fwrite(STDERR, "Cannot find '$insertBefore' entry after removal in: $filePath\n");
+        exit(1);
+    }
+
+    $insertSepPos = strrpos(substr($newContent, 0, $insertBeforePos2), ", '");
+    if ($insertSepPos === false) {
+        fwrite(STDERR, "Cannot find boundary for '$insertBefore' entry in: $filePath\n");
+        exit(1);
+    }
+
+    $insertEntryStart = $insertSepPos + 2;
+    $insertBeforeEntry = substr($newContent, $insertEntryStart, $insertBeforePos2 + strlen($insertBeforeMarker) - $insertEntryStart);
+
+    $newContent = str_replace($insertBeforeEntry, $entryToMove . ', ' . $insertBeforeEntry, $newContent);
+
+    if ($newContent === $content) {
+        fwrite(STDERR, "Reorder had no effect in: $filePath\n");
+        exit(1);
+    }
+
+    if (file_put_contents($filePath, $newContent) === false) {
+        fwrite(STDERR, "Failed to write reordered file: $filePath\n");
+        exit(1);
+    }
+
+    fwrite(STDOUT, "Reordered: '$pathToMove' now runs before '$insertBefore' in: $filePath\n");
+};
+
+$reorderAutoloadEntries(
+    $composerDir . 'autoload_files.php',
+    '/open-telemetry/exporter-otlp/_register.php',
+    '/open-telemetry/sdk/_autoload.php'
+);
+$reorderAutoloadEntries(
+    $composerDir . 'autoload_static.php',
+    '/open-telemetry/exporter-otlp/_register.php',
+    '/open-telemetry/sdk/_autoload.php'
+);


### PR DESCRIPTION
PhpPartFacade::earlySetup() registers the native OTLP serializer and async
transport factory as the very first Composer files autoload entry, ensuring
they are available before sdk/_autoload.php runs and before any instrumentation
_register.php files execute. This prevents race conditions where instrumentations
(e.g. tbachert/otel-instrumentation-runtime-metrics) eagerly call
Globals::meterProvider() inside register() and trigger SDK initialization before
the OTLP exporter factory is registered.

fix_scoped_composer_autoload.php gains two new post-scoping fixes:
- Fix 3: prepend earlySetup.php as the first entry in autoload_files/static
- Fix 5: reorder exporter-otlp/_register.php before sdk/_autoload.php
