### PR TITLE
feat: support local Composer package overrides for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ html_docs
 
 # For local development
 z_local*
+.local-repos.json
 
 # Per user PHPStan configuration
 phpstan.neon

--- a/.local-repos.json.example
+++ b/.local-repos.json.example
@@ -1,0 +1,5 @@
+{
+  "repositories": [
+    {"type": "path", "url": "/absolute/path/to/your/local/package"}
+  ]
+}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -171,6 +171,50 @@ instead of the usual `composer update`
 
 3) Commit the changes to the composer's lock files
 
+## Testing with unreleased/local PHP packages
+
+When a package is not yet published to Packagist, you can point the build system to a local checkout using a `.local-repos.json` file in the repository root. The file is gitignored.
+
+**Setup:**
+
+1. Copy the example and edit it:
+
+```bash
+cp .local-repos.json.example .local-repos.json
+```
+
+```json
+{
+  "repositories": [
+    {"type": "path", "url": "/absolute/path/to/your/local/package"}
+  ]
+}
+```
+
+2. Add the package to `require` in `composer.json` (if not already present):
+
+```json
+"open-telemetry/your-package-name": "*"
+```
+
+3. Regenerate lock files:
+
+```bash
+./tools/build/generate_composer_lock_files.sh --local-repos-file .local-repos.json
+```
+
+4. Build PHP dependencies:
+
+```bash
+./tools/build/build_php_code_for_packages.sh --php_versions '81 82 83 84 85' --skip_notice --local-repos-file .local-repos.json
+```
+
+**Caveats:**
+
+- Do not commit `generated_composer_lock_files/`, `composer.json`, or `.local-repos.json` while testing with local packages — the lock files reference local paths and `composer.json` contains a temporary `require` entry.
+- The local package's own `vendor/` directory is excluded from the build (dev tools like phpstan/psalm would otherwise be included and cause memory issues in php-scoper).
+- To restore normal CI/build behavior: remove `.local-repos.json`, revert the `composer.json` change, and regenerate lock files.
+
 ## Making a release
 
 Release process:

--- a/tools/build/build_php_code_for_packages.sh
+++ b/tools/build/build_php_code_for_packages.sh
@@ -5,6 +5,9 @@ set -e -u -o pipefail
 SKIP_NOTICE=false
 SKIP_VERIFY=false
 DEV_ONLY_RESCOPE_DISTRO=false
+LOCAL_REPOS_FILE=""
+LOCAL_REPOS_EXTRA_MOUNTS=()
+LOCAL_REPOS_OVERRIDE_CMDS=""
 current_user_id="$(id -u)"
 current_user_group_id="$(id -g)"
 
@@ -16,6 +19,9 @@ show_help() {
     echo "  --skip_notice              Optional. Skip notice file generator. Default: false (i.e., NOTICE file is generated)."
     echo "  --skip_verify              Optional. Skip verify step. Default: false (i.e., verify step is executed)."
     echo "  --dev_only_rescope_distro  Optional. Only re-scope distro code (prod/php/OpenTelemetry). Skips composer install and notice."
+    echo "  --local-repos-file         Optional. Path to a JSON file listing local Composer package paths for development (gitignored)."
+    echo "                             Each entry is mounted into Docker and overlaid onto vendor/ after composer install."
+    echo "                             See .local-repos.json.example. Default: none (packages installed from Packagist)."
     echo
     echo "Example:"
     echo "  $0 --php_versions '81 82 83 84 85' --skip_notice"
@@ -41,6 +47,10 @@ parse_args() {
         --dev_only_rescope_distro)
             DEV_ONLY_RESCOPE_DISTRO=true
             ;;
+        --local-repos-file)
+            LOCAL_REPOS_FILE="${2}"
+            shift
+            ;;
         --help)
             show_help
             exit 0
@@ -52,6 +62,42 @@ parse_args() {
             ;;
         esac
         shift
+    done
+}
+
+load_local_repos() {
+    if [ -z "${LOCAL_REPOS_FILE}" ]; then
+        return
+    fi
+    if [ ! -f "${LOCAL_REPOS_FILE}" ]; then
+        echo "Error: --local-repos-file not found: ${LOCAL_REPOS_FILE}"
+        exit 1
+    fi
+    echo "Using local repositories from: ${LOCAL_REPOS_FILE}"
+    local count
+    count=$(jq '.repositories | length' "${LOCAL_REPOS_FILE}")
+    local i
+    for (( i=0; i<count; i++ )); do
+        local host_path
+        host_path=$(jq -r ".repositories[${i}].url" "${LOCAL_REPOS_FILE}")
+        local docker_path="/local_repos/${i}"
+        if [ ! -d "${host_path}" ]; then
+            echo "Warning: local repo path does not exist, skipping: ${host_path}"
+            continue
+        fi
+        echo "  [${i}] ${host_path} -> ${docker_path}"
+        LOCAL_REPOS_EXTRA_MOUNTS+=(-v "${host_path}:${docker_path}:ro")
+        # \$(...) is intentionally escaped so the subshell runs inside the container, not on the host.
+        # If composer installed via symlink (path repo), replace with real files so the copy to host
+        # and php-scoper work correctly (symlinks to /local_repos/* are invalid outside the container).
+        # Exclude vendor/ from the copy: a published package never ships its own dev vendor tree,
+        # and copying it would feed huge dev-only files (phpstan.phar, psalm dictionaries) into php-scoper.
+        LOCAL_REPOS_OVERRIDE_CMDS+="\
+            && echo 'Overriding vendor with local repo: ${host_path}' \
+            && _pkg_vendor_dir=/tmp/repo/vendor/\$(jq -r .name ${docker_path}/composer.json) \
+            && if [ -L \"\${_pkg_vendor_dir}\" ]; then rm \"\${_pkg_vendor_dir}\" && cp -rf ${docker_path}/. \"\${_pkg_vendor_dir}/\" && rm -rf \"\${_pkg_vendor_dir}/vendor/\"; \
+               elif [ \"\$(realpath ${docker_path} 2>/dev/null)\" != \"\$(realpath \${_pkg_vendor_dir} 2>/dev/null)\" ]; then cp -rf ${docker_path}/. \"\${_pkg_vendor_dir}/\" && rm -rf \"\${_pkg_vendor_dir}/vendor/\"; fi \
+        "
     done
 }
 
@@ -135,6 +181,7 @@ main() {
 
     # Parse arguments
     parse_args "$@"
+    load_local_repos
 
     # Validate required arguments
     # SC2128: Expanding an array without an index only gives the first element.
@@ -239,6 +286,9 @@ main() {
             -v "${repo_root_dir}/:/read_only_repo_root/:ro"
             -v "${_BUILT_PHP_CODE_FOR_PACKAGES_DIR}/:/docker_host_dst_php_code_for_packages/"
         )
+        if [ "${#LOCAL_REPOS_EXTRA_MOUNTS[@]}" -gt 0 ]; then
+            docker_mount_args+=("${LOCAL_REPOS_EXTRA_MOUNTS[@]}")
+        fi
         local docker_sh_cmd=""
 
         # See prod/php/bootstrap_php_part.php for the layout of PHP code after package is installed
@@ -301,14 +351,21 @@ main() {
 
             docker_mount_args+=("${docker_notice_mount_args[@]}")
 
+            local _APK_EXTRA_PKGS="bash"
+            local VERIFY_LOCK_FILES_CMD="cd /read_only_repo_root/ && php ./tools/build/verify_generated_composer_lock_files.php"
+            if [ "${#LOCAL_REPOS_EXTRA_MOUNTS[@]}" -gt 0 ]; then
+                _APK_EXTRA_PKGS="bash jq"
+                VERIFY_LOCK_FILES_CMD="echo 'Skipping verify_generated_composer_lock_files: local repos in use (dev mode)'"
+            fi
+
             docker_sh_cmd="\
-                apk update && apk add bash \
+                apk update && apk add ${_APK_EXTRA_PKGS} \
                 && curl -sS https://getcomposer.org/installer | php -- --filename=composer --install-dir=/usr/local/bin \
-                && cd /read_only_repo_root/ && php ./tools/build/verify_generated_composer_lock_files.php \
+                && ${VERIFY_LOCK_FILES_CMD} \
                 && ${COPY_REPO_TO_TMP_CMD} \
                 && rm -rf composer.json composer.lock ./vendor/ \
                 && php ./tools/build/select_json_lock_and_install_PHP_deps.php prod \
-                \
+                ${LOCAL_REPOS_OVERRIDE_CMDS} \
                 && rm -rf ${_NOT_SCOPED_VENDOR_PHP_VERSION_IN_DOCKER_DIR} \
                 && mkdir -p ${_NOT_SCOPED_VENDOR_PHP_VERSION_IN_DOCKER_DIR} \
                 && cp -r /tmp/repo/vendor/. ${_NOT_SCOPED_VENDOR_PHP_VERSION_IN_DOCKER_DIR}/ \

--- a/tools/build/generate_composer_lock_files.sh
+++ b/tools/build/generate_composer_lock_files.sh
@@ -2,11 +2,18 @@
 set -e -u -o pipefail
 #set -x
 
+LOCAL_REPOS_FILE=""
+LOCAL_REPOS_EXTRA_MOUNTS=()
+LOCAL_REPOS_HOST_PATHS=()
+
 function show_help() {
     echo "Usage: $0 [optional arguments]"
     echo
     echo "Options:"
     echo "  --keep_temp_files       Optional. Keep temporary files. Default: false (i.e., delete temporary files on both success and failure)."
+    echo "  --local-repos-file      Optional. Path to a JSON file listing local Composer package paths for development (gitignored)."
+    echo "                          Each entry is mounted into Docker as a path repository so Composer can resolve dev packages."
+    echo "                          See .local-repos.json.example. Default: none (packages installed from Packagist)."
     echo
     echo "Example:"
     echo "  $0 --keep_temp_files"
@@ -21,6 +28,10 @@ function parse_args() {
         --keep_temp_files)
             export OTEL_PHP_TOOLS_KEEP_TEMP_FILES="true"
             ;;
+        --local-repos-file)
+            LOCAL_REPOS_FILE="${2}"
+            shift
+            ;;
         --help)
             show_help
             exit 0
@@ -33,6 +44,53 @@ function parse_args() {
         esac
         shift
     done
+}
+
+function load_local_repos() {
+    if [ -z "${LOCAL_REPOS_FILE}" ]; then
+        return
+    fi
+    if [ ! -f "${LOCAL_REPOS_FILE}" ]; then
+        echo "Error: --local-repos-file not found: ${LOCAL_REPOS_FILE}"
+        exit 1
+    fi
+    echo "Using local repositories from: ${LOCAL_REPOS_FILE}"
+    local count
+    count=$(jq '.repositories | length' "${LOCAL_REPOS_FILE}")
+    local i
+    local j=0
+    for (( i=0; i<count; i++ )); do
+        local host_path
+        host_path=$(jq -r ".repositories[${i}].url" "${LOCAL_REPOS_FILE}")
+        if [ ! -d "${host_path}" ]; then
+            echo "Warning: local repo path does not exist, skipping: ${host_path}"
+            continue
+        fi
+        local docker_path="/local_repos/${j}"
+        echo "  [${j}] ${host_path} -> ${docker_path}"
+        LOCAL_REPOS_EXTRA_MOUNTS+=(-v "${host_path}:${docker_path}:ro")
+        LOCAL_REPOS_HOST_PATHS+=("${host_path}")
+        j=$(( j + 1 ))
+    done
+}
+
+function patch_composer_json_with_local_repos() {
+    local _json_path="${1:?}"
+    if [ ${#LOCAL_REPOS_HOST_PATHS[@]} -eq 0 ]; then
+        return
+    fi
+    local repos_json="["
+    local i
+    for (( i=0; i<${#LOCAL_REPOS_HOST_PATHS[@]}; i++ )); do
+        if [ $i -gt 0 ]; then repos_json+=","; fi
+        repos_json+="{\"type\":\"path\",\"url\":\"/local_repos/${i}\"}"
+    done
+    repos_json+="]"
+    local tmp
+    tmp=$(mktemp)
+    jq --argjson new_repos "${repos_json}" '.repositories = ($new_repos + (.repositories // []))' "${_json_path}" > "${tmp}"
+    mv "${tmp}" "${_json_path}"
+    echo "Patched ${_json_path} with ${#LOCAL_REPOS_HOST_PATHS[@]} local repo(s)"
 }
 
 function build_command_to_derive_for_prod() {
@@ -271,10 +329,16 @@ function generate_composer_lock_for_PHP_version() {
         docker_cmds_for_PHP_81+=("&&" cp "/from_docker_host/${_COMPOSER_HOME_FOR_PACKAGES_ADAPTED_TO_PHP_81_REL_PATH:?}/"* "/repo_root/${_COMPOSER_HOME_FOR_PACKAGES_ADAPTED_TO_PHP_81_REL_PATH:?}/")
     fi
 
+    local docker_local_repos_mounts=()
+    if [ "${#LOCAL_REPOS_EXTRA_MOUNTS[@]}" -gt 0 ]; then
+        docker_local_repos_mounts=("${LOCAL_REPOS_EXTRA_MOUNTS[@]}")
+    fi
+
     docker run --rm \
         -v "${composer_json_full_path}:/repo_root/composer.json:ro" \
         -v "${_STAGE_DIR}:/from_docker_host/generated_composer_lock_files_stage_dir" \
         "${docker_args_for_PHP_81[@]}" \
+        "${docker_local_repos_mounts[@]+"${docker_local_repos_mounts[@]}"}" \
         -w "/repo_root" \
         "${PHP_docker_image}" \
         sh -c "\
@@ -307,6 +371,7 @@ function main() {
 
     # Parse arguments
     parse_args "$@"
+    load_local_repos
 
     current_user_id="$(id -u)"
     current_user_group_id="$(id -g)"
@@ -357,6 +422,9 @@ function main() {
         derive_composer_json_for_env_kind "${GENERATED_COMPOSER_LOCK_FILES_STAGE_DIR}" "${env_kind}"
     done
 
+    for env_kind in "dev" "prod" "prod_static_check" "test"; do
+        patch_composer_json_with_local_repos "$(build_generated_composer_json_full_path "${GENERATED_COMPOSER_LOCK_FILES_STAGE_DIR}" "${env_kind}")"
+    done
 
     # SC2086: Double quote to prevent globbing and word splitting.
     # shellcheck disable=SC2086
@@ -366,12 +434,16 @@ function main() {
         done
     done
 
-    docker run --rm \
-        -v "${repo_root_dir}:/read_only_repo_root:ro" \
-        -v "${_REPO_TEMP_COPY_DIR}:/repo_temp_copy_dir" \
-        -w "/repo_temp_copy_dir" \
-        "${_PHP_docker_image_for_tools}" \
-        sh -c "php /read_only_repo_root/tools/build/verify_generated_composer_lock_files.php"
+    if [ ${#LOCAL_REPOS_HOST_PATHS[@]} -eq 0 ]; then
+        docker run --rm \
+            -v "${repo_root_dir}:/read_only_repo_root:ro" \
+            -v "${_REPO_TEMP_COPY_DIR}:/repo_temp_copy_dir" \
+            -w "/repo_temp_copy_dir" \
+            "${_PHP_docker_image_for_tools}" \
+            sh -c "php /read_only_repo_root/tools/build/verify_generated_composer_lock_files.php"
+    else
+        echo "Skipping verify_generated_composer_lock_files: local repos in use (dev mode)"
+    fi
 
     mkdir -p "${_PROJECT_PROPERTIES_GENERATED_LOCK_FILES_FOLDER:?}"
     delete_dir_contents "${_PROJECT_PROPERTIES_GENERATED_LOCK_FILES_FOLDER:?}"

--- a/tools/shared.sh
+++ b/tools/shared.sh
@@ -4,10 +4,10 @@ set -e -u -o pipefail
 
 # return the repo root dir if the script is run from the repo root dir
 function verify_running_from_repo_root() {
-    if [ ! -d "${PWD}/.git" ]; then
+    if [ ! -e "${PWD}/.git" ]; then
         echo "Error: This script must be run from the repository root directory"
         echo "Current directory: ${PWD}"
-        echo "Expected: A directory containing a .git subdirectory"
+        echo "Expected: A directory containing a .git subdirectory (or .git file for submodules)"
         exit 1
     fi
     echo "$(realpath ${PWD})"


### PR DESCRIPTION
Add --local-repos-file option to build_php_code_for_packages.sh and generate_composer_lock_files.sh. When a gitignored .local-repos.json file is present, listed local paths are mounted into Docker and used as Composer path repositories, overriding packages from Packagist.

- Remove hardcoded local SDK path from build_php_code_for_packages.sh
- Fix verify_running_from_repo_root to accept .git file (submodule)
- Add .local-repos.json.example and document workflow in DEVELOPMENT.md