### PR TITLE
fix: hook() no longer requires the target class/function to already be declared

### DIFF
--- a/prod/native/extension/code/InternalFunctionInstrumentation.cpp
+++ b/prod/native/extension/code/InternalFunctionInstrumentation.cpp
@@ -5,6 +5,7 @@
 #include "WithSpanAttributes.h"
 #include "AttrHooksStorage.h"
 #include "LoggerInterface.h"
+#include "Helpers.h"
 
 #include "Zend/zend.h"
 #include "Zend/zend_exceptions.h"
@@ -427,62 +428,34 @@ bool instrumentFunction(LoggerInterface *log, std::string_view cName, std::strin
     std::transform(className.begin(), className.end(), className.begin(), [](unsigned char c){ return std::tolower(c); });
     std::transform(functionName.begin(), functionName.end(), functionName.begin(), [](unsigned char c){ return std::tolower(c); });
 
-    HashTable *table = nullptr;
-    zend_ulong classHash = 0;
-
-    if (className.empty()) { // looking for function
-        table = EG(function_table);
-    } else {
-        if (!EG(class_table)) {
-            ELOGF_DEBUG(log, INSTRUMENTATION, "instrumentFunction Class table is empty. Function " PRsv "::" PRsv " not found and cannot be instrumented.", PRsvArg(className), PRsvArg(functionName));
-            return false;
-        }
-
-        auto ce = static_cast<zend_class_entry *>(zend_hash_str_find_ptr(EG(class_table), className.data(), className.length()));
-        if (!ce) {
-            ELOGF_DEBUG(log, INSTRUMENTATION, "instrumentFunction Class not found. Function " PRsv "::" PRsv " not found and cannot be instrumented.", PRsvArg(className), PRsvArg(functionName));
-
-            if (log->doesMeetsLevelCondition(logLevel_trace)) {
-                zend_string *argStrKey = nullptr;
-                ZEND_HASH_FOREACH_STR_KEY(EG(class_table), argStrKey) {
-                    if (argStrKey) {
-                        ELOGF_DEBUG(log, INSTRUMENTATION, "instrumentFunction Class not found. Function " PRsv "::" PRsv " not found and cannot be instrumented. %s", PRsvArg(className), PRsvArg(functionName), ZSTR_VAL(argStrKey));
-                    }
-                }
-                ZEND_HASH_FOREACH_END();
-            }
-
-            return false;
-        }
-
-        table = &ce->function_table;
-        classHash = ZSTR_HASH(ce->name);
-    }
-
-    if (!table) {
-        return false;
-    }
-
-   	zend_function *func = reinterpret_cast<zend_function *>(zend_hash_str_find_ptr(table, functionName.data(), functionName.length()));
-    if (!func) {
-        ELOGF_DEBUG(log, INSTRUMENTATION, "instrumentFunction " PRsv "::" PRsv " not found and cannot be instrumented.", PRsvArg(className), PRsvArg(functionName));
-        return false;
-    }
-
-    zend_ulong funcHash = ZSTR_HASH(func->common.function_name);
-    zend_ulong hash = classHash ^ (funcHash << 1);
-
-    ELOGF_DEBUG(log, INSTRUMENTATION, "instrumentFunction 0x%X " PRsv "::" PRsv " type: %s is marked to be instrumented", hash, PRsvArg(className), PRsvArg(functionName), func->common.type == ZEND_INTERNAL_FUNCTION ? "internal" : "user");
+    zend_ulong hash = hashClassAndFunctionNameLowercase(className, functionName);
 
     reinterpret_cast<InstrumentedFunctionHooksStorage_t *>(OTEL_GL(hooksStorage_).get())->store(hash, AutoZval{callableOnEntry}, AutoZval{callableOnExit});
 
-    // we only keep original handler for internal (native) functions
-    if (func->common.type == ZEND_INTERNAL_FUNCTION) {
+    ELOGF_DEBUG(log, INSTRUMENTATION, "instrumentFunction 0x%X " PRsv "::" PRsv " hook stored", hash, PRsvArg(className), PRsvArg(functionName));
+
+    // Internal (native) functions don't go through zend_observer here (not supported on PHP 8.1), so their zif_handler must be patched eagerly. This requires the function to already be resolvable.
+    HashTable *table = nullptr;
+    if (className.empty()) {
+        table = EG(function_table);
+    } else if (EG(class_table)) {
+        auto ce = static_cast<zend_class_entry *>(zend_hash_str_find_ptr(EG(class_table), className.data(), className.length()));
+        if (ce) {
+            table = &ce->function_table;
+        }
+    }
+
+    zend_function *func = table ? reinterpret_cast<zend_function *>(zend_hash_str_find_ptr(table, functionName.data(), functionName.length())) : nullptr;
+    if (!func) {
+        ELOGF_DEBUG(log, INSTRUMENTATION, "instrumentFunction " PRsv "::" PRsv " not resolvable yet - hook left for lazy zend_observer resolution.", PRsvArg(className), PRsvArg(functionName));
+    } else if (func->common.type == ZEND_INTERNAL_FUNCTION) {
         if (func->internal_function.handler != internal_function_handler) {
             InternalStorage_t::getInstance().store(hash, func->internal_function.handler);
             func->internal_function.handler = internal_function_handler;
         }
-        ELOGF_DEBUG(log, INSTRUMENTATION, PRsv "::" PRsv " instrumented, key: 0x%X", PRsvArg(className), PRsvArg(functionName), hash);
+        ELOGF_DEBUG(log, INSTRUMENTATION, "instrumentFunction " PRsv "::" PRsv " instrumented as internal function, key: 0x%X", PRsvArg(className), PRsvArg(functionName), hash);
+    } else {
+        ELOGF_DEBUG(log, INSTRUMENTATION, "instrumentFunction " PRsv "::" PRsv " already declared as a user-space function - will be instrumented on first call, key: 0x%X", PRsvArg(className), PRsvArg(functionName), hash);
     }
 
     return true;
@@ -569,9 +542,9 @@ zend_observer_fcall_handlers registerObserverHandlers(zend_execute_data *execute
         auto ce = execute_data->func->common.scope;
         if (ce) {
             for (uint32_t i = 0; i < ce->num_interfaces; ++i) {
-                auto classHash = ZSTR_HASH(ce->interfaces[i]->name);
-                zend_ulong funcHash = ZSTR_HASH(execute_data->func->common.function_name);
-                zend_ulong ifaceHash = classHash ^ (funcHash << 1);
+                std::string_view ifaceName{ZSTR_VAL(ce->interfaces[i]->name), ZSTR_LEN(ce->interfaces[i]->name)};
+                std::string_view funcName{ZSTR_VAL(execute_data->func->common.function_name), ZSTR_LEN(execute_data->func->common.function_name)};
+                zend_ulong ifaceHash = hashClassAndFunctionNameLowercase(ifaceName, funcName);
 
                 callbacks = reinterpret_cast<InstrumentedFunctionHooksStorage_t *>(OTEL_GL(hooksStorage_).get())->find(ifaceHash);
                 if (callbacks) {

--- a/prod/native/extension/phpt/tests/instrumentation_user_method_mixed_case_retry.phpt
+++ b/prod/native/extension/phpt/tests/instrumentation_user_method_mixed_case_retry.phpt
@@ -1,5 +1,5 @@
 --TEST--
-instrumentation - user method - hook placed before class is declared fires on first call
+instrumentation - user method - mixed case hook placed before class is declared fires on first call
 --ENV--
 OTEL_PHP_LOG_LEVEL_STDERR=INFO
 --INI--
@@ -9,9 +9,7 @@ opentelemetry_distro.bootstrap_php_part_file={PWD}/includes/bootstrap_mock.inc
 <?php
 declare(strict_types=1);
 
-echo "Hooking class doesn't exist yet:".PHP_EOL;
-
-var_dump(\OpenTelemetry\Distro\hook("testclass", "userspace", function () {
+var_dump(\OpenTelemetry\Distro\hook("TESTCLASS", "USERSPACE", function () {
 	echo "*** prehook userspace()\n";
  }, function () {
 	echo "*** posthook userspace()\n";
@@ -26,7 +24,6 @@ var_dump($obj->userspace("first", 2, 3));
 echo "Test completed\n";
 ?>
 --EXPECTF--
-Hooking class doesn't exist yet:
 bool(true)
 *** prehook userspace()
 * userspace() body start.

--- a/prod/native/libphpbridge/code/AttrHooksStorage.h
+++ b/prod/native/libphpbridge/code/AttrHooksStorage.h
@@ -10,14 +10,22 @@ namespace opentelemetry::php {
 // Per-process singleton mapping function hash → WithSpanMetadata for
 // attribute-based (#[WithSpan]) instrumentation.
 //
-// Lifecycle: populated once per function from registerObserverHandlers(),
-// persists for the entire process lifetime — required because with opcache
-// the Zend observer calls registerObserverHandlers() only ONCE per function
-// per process (subsequent requests reuse the cached op_array with handlers
-// already installed).  Clearing per-request (like hooksStorage_) would break
-// attribute hooks on the second request.
+// Lifecycle: populated from registerObserverHandlers(), which re-runs on the first call of a
+// given function within each request (zend_activate() resets the map-pointer-backed run_time_cache,
+// including the observer install slot, at the start of every request - it is NOT a once-per-process
+// thing). Unlike hooksStorage_, this is never cleared at request shutdown: WithSpanMetadata holds
+// no PHP-owned memory (every field is a deep copy into std::string/std::vector, see
+// WithSpanAttributes.cpp) so nothing here depends on PHP's per-request memory pool - it's safe to
+// keep across requests purely as a cache to avoid re-parsing attributes every time.
 //
-// TODO: ZTS — concurrent emplace() and find() are not thread-safe.
+// store() unconditionally overwrites rather than no-op'ing on an existing key: the hash depends
+// only on the (lowercased) class+function name, not on which compiled version of the code defined
+// it. Live code deploys under a warm worker (opcache re-detects the changed file, recompiles a new
+// op_array, and registerObserverHandlers() re-reads the now-current #[WithSpan] attribute) must be
+// able to replace a stale cached value, not have it permanently rejected by an emplace() no-op -
+// otherwise a changed span_name/attributes would stay stuck until the worker process recycles.
+//
+// TODO: ZTS — concurrent store() and find() are not thread-safe.
 //       Add std::shared_mutex when ZTS support is needed (same caveat as
 //       InternalFunctionInstrumentationStorage).
 class AttrHooksStorage {
@@ -36,10 +44,10 @@ public:
         return &it->second;
     }
 
-    // No-op if hash is already present (idempotent — safe for non-opcache
-    // environments where registerObserverHandlers may run per-request).
+    // Always overwrites any existing entry for this hash - see class comment above for why a
+    // no-op-if-present (emplace) semantics would be wrong here.
     void store(zend_ulong hash, WithSpanMetadata meta) {
-        storage_.emplace(hash, std::move(meta));
+        storage_[hash] = std::move(meta);
     }
 
 private:

--- a/prod/native/libphpbridge/code/Helpers.cpp
+++ b/prod/native/libphpbridge/code/Helpers.cpp
@@ -1,8 +1,31 @@
 #include "Helpers.h"
 #include <optional>
 #include <tuple>
+#include <cctype>
+#include <Zend/zend_string.h>
 
 namespace opentelemetry::php {
+
+// Same DJBX33A recurrence as zend_inline_hash_func (the multi-byte-at-a-time version there is
+// just an algebraic unrolling of this same per-byte formula), computed with an on-the-fly
+// tolower() so no lowercased copy of the string needs to be allocated.
+zend_ulong lowercaseHash(std::string_view sv) {
+    zend_ulong hash = Z_UL(5381);
+    for (unsigned char c : sv) {
+        hash = hash * 33 + static_cast<unsigned char>(std::tolower(c));
+    }
+
+    // zend_inline_hash_func()/ZSTR_HASH() unconditionally set the high bit so the hash value
+    // can never be zero (Zend reserves 0 as the "not yet computed" sentinel for a cached
+    // zend_string hash). Mirrored here so this is bit-identical to PHP's own hash function.
+#if SIZEOF_ZEND_LONG == 8
+    return hash | Z_UL(0x8000000000000000);
+#elif SIZEOF_ZEND_LONG == 4
+    return hash | Z_UL(0x80000000);
+#else
+# error "Unknown SIZEOF_ZEND_LONG"
+#endif
+}
 
 std::optional<std::string_view> zvalToOptionalStringView(zval *zv) {
     if (!zv || Z_TYPE_P(zv) != IS_STRING) {
@@ -19,20 +42,19 @@ std::string_view zvalToStringView(zval *zv) {
     return {Z_STRVAL_P(zv), Z_STRLEN_P(zv)};
 }
 
+zend_ulong hashClassAndFunctionNameLowercase(std::string_view className, std::string_view functionName) {
+    zend_ulong classHash = className.empty() ? 0 : lowercaseHash(className);
+    zend_ulong funcHash = lowercaseHash(functionName);
+    return classHash ^ (funcHash << 1);
+}
+
 zend_ulong getClassAndFunctionHashFromExecuteData(zend_execute_data *execute_data) {
     if (!execute_data || !execute_data->func || !execute_data->func->common.function_name) {
         return 0;
     }
 
-    zend_ulong classHash = 0;
-    if (execute_data->func->common.scope && execute_data->func->common.scope->name) {
-        classHash = ZSTR_HASH(execute_data->func->common.scope->name);
-    }
-
-
-    zend_ulong funcHash = ZSTR_HASH(execute_data->func->common.function_name);
-    zend_ulong hash = classHash ^ (funcHash << 1);
-    return hash;
+    auto [className, functionName] = getClassAndFunctionName(execute_data);
+    return hashClassAndFunctionNameLowercase(className, functionName);
 }
 
 std::tuple<std::string_view, std::string_view> getClassAndFunctionName(zend_execute_data *execute_data) {

--- a/prod/native/libphpbridge/code/Helpers.h
+++ b/prod/native/libphpbridge/code/Helpers.h
@@ -13,4 +13,8 @@ std::optional<std::string_view> zvalToOptionalStringView(zval *zv);
 zend_ulong getClassAndFunctionHashFromExecuteData(zend_execute_data *execute_data);
 std::tuple<std::string_view, std::string_view> getClassAndFunctionName(zend_execute_data *execute_data);
 
+zend_ulong hashClassAndFunctionNameLowercase(std::string_view className, std::string_view functionName);
+
+/// Same DJBX33A recurrence as zend_inline_hash_func()/ZSTR_HASH(), computed with an on-the-fly tolower()
+zend_ulong lowercaseHash(std::string_view sv);
 }

--- a/prod/native/phpbridge_extension/code/BridgeModuleFunctions.cpp
+++ b/prod/native/phpbridge_extension/code/BridgeModuleFunctions.cpp
@@ -3,6 +3,8 @@
 #include "AutoZval.h"
 #include "PhpBridge.h"
 #include "WithSpanAttributes.h"
+#include "Helpers.h"
+#include <Zend/zend_string.h>
 
 #include <main/php.h>
 #include <Zend/zend_API.h>
@@ -468,6 +470,76 @@ PHP_FUNCTION(getWithSpanMetadata) {
     RETURN_COPY(result.get());
 }
 
+// Exposes opentelemetry::php::hashClassAndFunctionNameLowercase() directly so phpt tests can
+// verify it against the hash zend_observer actually computes for a real call
+// (see getCurrentCallHash below) without needing to resolve the class/function at all.
+PHP_FUNCTION(hashClassAndFunctionNameLowercase) {
+    char *className = nullptr;
+    size_t classNameLen = 0;
+    char *functionName = nullptr;
+    size_t functionNameLen = 0;
+
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+    Z_PARAM_STRING(className, classNameLen)
+    Z_PARAM_STRING(functionName, functionNameLen)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_ulong hash = opentelemetry::php::hashClassAndFunctionNameLowercase(std::string_view(className, classNameLen), std::string_view(functionName, functionNameLen));
+    RETURN_LONG(static_cast<zend_long>(hash));
+}
+
+// Exposes opentelemetry::php::getClassAndFunctionHashFromExecuteData() for a real call frame -
+// i.e. the hash the observer dispatch path (registerObserverHandlers/observerFcallBeginHandler/
+// observerFcallEndHandler) would compute for that call. framesBack follows the same convention
+// as getFunctionName() above: 0 is this internal function's own frame, 1 is its immediate caller.
+PHP_FUNCTION(getCurrentCallHash) {
+    long framesBack = 0;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+    Z_PARAM_LONG(framesBack)
+    ZEND_PARSE_PARAMETERS_END();
+
+    auto execData = EG(current_execute_data);
+    for (auto frame = 0; frame < framesBack; ++frame) {
+        execData = execData->prev_execute_data;
+        if (!execData) {
+            BRIDGE_G(globals)->logger->printf(LogLevel::logLevel_error, "test failure, can't go %d frames back", framesBack);
+            RETURN_NULL();
+            return;
+        }
+    }
+
+    zend_ulong hash = opentelemetry::php::getClassAndFunctionHashFromExecuteData(execData);
+    RETURN_LONG(static_cast<zend_long>(hash));
+}
+
+// Exposes opentelemetry::php::lowercaseHash() - our own DJBX33A-with-inline-tolower reimplementation - so it can be compared directly against PHP's actual built-in hash
+// function (zendBuiltinStringHash below) for the same (already-lowercased) bytes.
+PHP_FUNCTION(lowercaseHash) {
+    char *str = nullptr;
+    size_t strLen = 0;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+    Z_PARAM_STRING(str, strLen)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_ulong hash = opentelemetry::php::lowercaseHash(std::string_view(str, strLen));
+    RETURN_LONG(static_cast<zend_long>(hash));
+}
+
+// Exposes PHP's actual built-in string hash function (zend_inline_hash_func, the same recurrence ZSTR_HASH() uses) directly, with no lowering
+PHP_FUNCTION(zendBuiltinStringHash) {
+    char *str = nullptr;
+    size_t strLen = 0;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+    Z_PARAM_STRING(str, strLen)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_ulong hash = zend_inline_hash_func(str, strLen);
+    RETURN_LONG(static_cast<zend_long>(hash));
+}
+
 ZEND_BEGIN_ARG_INFO(no_paramters_arginfo, 0)
 ZEND_END_ARG_INFO()
 
@@ -500,6 +572,11 @@ const zend_function_entry phpbridge_functions[] = {
     PHP_FE( getPhpVersionMajorMinor, no_paramters_arginfo )
 
     PHP_FE( getWithSpanMetadata, no_paramters_arginfo )
+
+    PHP_FE( hashClassAndFunctionNameLowercase, no_paramters_arginfo )
+    PHP_FE( getCurrentCallHash, no_paramters_arginfo )
+    PHP_FE( lowercaseHash, no_paramters_arginfo )
+    PHP_FE( zendBuiltinStringHash, no_paramters_arginfo )
 
     PHP_FE_END
 };

--- a/prod/native/phpbridge_extension/phpt/tests/hashClassAndFunctionNameLowercase.phpt
+++ b/prod/native/phpbridge_extension/phpt/tests/hashClassAndFunctionNameLowercase.phpt
@@ -1,0 +1,36 @@
+--TEST--
+hashClassAndFunctionNameLowercase matches the hash zend_observer computes for a real call, case-insensitively
+--INI--
+extension=/otel/phpbridge.so
+--FILE--
+<?php
+declare(strict_types=1);
+
+class TestClass {
+    public function userSpace() {
+        return getCurrentCallHash(1);
+    }
+}
+
+$obj = new TestClass;
+$realHash = $obj->userSpace();
+
+// Same class/function, different case, computed with no class/function resolution at all -
+// must equal the hash the observer dispatch path computed for the real, declared-case call.
+var_dump($realHash === hashClassAndFunctionNameLowercase("TESTCLASS", "USERSPACE"));
+var_dump($realHash === hashClassAndFunctionNameLowercase("testclass", "userspace"));
+var_dump($realHash === hashClassAndFunctionNameLowercase("TestClass", "userSpace"));
+
+// Sanity: a different name must not collide.
+var_dump($realHash === hashClassAndFunctionNameLowercase("TestClass", "otherMethod"));
+var_dump($realHash === hashClassAndFunctionNameLowercase("OtherClass", "userSpace"));
+
+echo 'Test completed';
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+Test completed

--- a/prod/native/phpbridge_extension/phpt/tests/lowercaseHash_matchesZendBuiltinHash.phpt
+++ b/prod/native/phpbridge_extension/phpt/tests/lowercaseHash_matchesZendBuiltinHash.phpt
@@ -1,0 +1,57 @@
+--TEST--
+lowercaseHash produces the same value as PHP's actual built-in string hash for the lowercased bytes, across all zend_inline_hash_func unrolled-loop length boundaries
+--INI--
+extension=/otel/phpbridge.so
+--FILE--
+<?php
+declare(strict_types=1);
+
+$strings = [
+    "",                                    // 0 bytes
+    "a",                                   // 1
+    "AB",                                  // 2
+    "ABC",                                 // 3
+    "ABCD",                                // 4
+    "ABCDE",                               // 5
+    "ABCDEF",                              // 6
+    "ABCDEFG",                             // 7
+    "ABCDEFGH",                            // 8 - first 8-byte chunk boundary
+    "ABCDEFGHI",                           // 9 - 8-byte chunk + 1
+    "ABCDEFGHIJKLMNO",                     // 15
+    "ABCDEFGHIJKLMNOP",                    // 16 - two 8-byte chunks
+    "ABCDEFGHIJKLMNOPQ",                   // 17 - two chunks + 1
+    "TestClass",
+    "userSpace",
+    "Illuminate\\Foundation\\Application",
+    "PDOStatement",
+    "cURL_INIT",
+];
+
+foreach ($strings as $s) {
+    $ours = lowercaseHash($s);
+    $zend = zendBuiltinStringHash(strtolower($s));
+    var_dump($ours === $zend);
+}
+
+echo 'Test completed';
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+Test completed

--- a/prod/php/OpenTelemetry/Distro/InstrumentationBridge.php
+++ b/prod/php/OpenTelemetry/Distro/InstrumentationBridge.php
@@ -67,10 +67,6 @@ final class InstrumentationBridge
         $logTrace = self::logTrace(__FUNCTION__);
         $logTrace?->with(__LINE__, 'Entered', compact('class', 'function'));
 
-        if ($class !== null) {
-            class_exists($class) || interface_exists($class);
-        }
-
         $success = self::nativeHookNoThrow($class, $function, $pre, $post);
 
         if ($this->enableDebugHooks) {


### PR DESCRIPTION
Distro's hook() computed its lookup hash from the resolved (declared-case) zend_class_entry/zend_function names, so it silently failed (returning false, never registering anything) whenever the target class hadn't been autoloaded/declared yet. This differed from upstream opentelemetry-php-instrumentation's purely name-based matching and made hook() ordering-sensitive.

The hash now depends only on the (lowercased) class/function name strings, computed the same way on both the registration side (instrumentFunction) and the dispatch side (getClassAndFunctionHashFromExecuteData), so hook() stores the callback regardless of whether the class exists yet - zend_observer resolves it lazily at the function's first real call. Internal (native) function patching is unaffected, since it genuinely needs a live zend_function* and is unrelated to this hash.

Also fixes AttrHooksStorage (#[WithSpan] metadata cache) to overwrite instead of no-op on an existing key, so a live code deploy under a warm worker doesn't get stuck serving stale span_name/attributes until the worker recycles.