### PR TITLE
fix: reenabled Inferred Spans component test

### DIFF
--- a/tests/OTelDistroTests/ComponentTests/InferredSpansComponentTest.php
+++ b/tests/OTelDistroTests/ComponentTests/InferredSpansComponentTest.php
@@ -209,11 +209,6 @@ final class InferredSpansComponentTest extends ComponentTestCaseBase
      */
     public function testInferredSpans(MixedMap $testArgs): void
     {
-        // TODO: Re-enable InferredSpansComponentTest::testInferredSpans - Temporarily disabled this test and we will fix in a separate PR
-        if (self::dummyAssert()) {
-            return;
-        }
-
         $this->runAndEscalateLogLevelOnFailure(
             self::buildDbgDescForTestWithArgs(__CLASS__, __FUNCTION__, $testArgs),
             function () use ($testArgs): void {

--- a/tests/OTelDistroTests/ComponentTests/Util/AgentBackendComms.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/AgentBackendComms.php
@@ -62,8 +62,34 @@ final class AgentBackendComms
      */
     public function spans(): iterable
     {
+        // Build the discard set across ALL batches so that cross-batch parent→child
+        // relationships are handled: a child span exported before its parent still gets
+        // discarded once the parent is seen in a later batch.
+        /** @var array<string, true> $discardedSpanIds */
+        $discardedSpanIds = [];
         foreach ($this->intakeTraceDataRequests() as $request) {
-            yield from $request->spans();
+            foreach ($request->directlyDiscardedSpanIds() as $spanId) {
+                $discardedSpanIds[$spanId] = true;
+            }
+        }
+        do {
+            $changed = false;
+            foreach ($this->intakeTraceDataRequests() as $request) {
+                foreach ($request->spans() as $span) {
+                    if (!isset($discardedSpanIds[$span->id]) && $span->parentId !== null && isset($discardedSpanIds[$span->parentId])) {
+                        $discardedSpanIds[$span->id] = true;
+                        $changed = true;
+                    }
+                }
+            }
+        } while ($changed);
+
+        foreach ($this->intakeTraceDataRequests() as $request) {
+            foreach ($request->spans() as $span) {
+                if (!isset($discardedSpanIds[$span->id])) {
+                    yield $span;
+                }
+            }
         }
     }
 

--- a/tests/OTelDistroTests/ComponentTests/Util/IntakeTraceDataRequest.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/IntakeTraceDataRequest.php
@@ -49,6 +49,14 @@ final class IntakeTraceDataRequest extends IntakeDataRequestDeserialized
     }
 
     /**
+     * @return iterable<string>
+     */
+    public function directlyDiscardedSpanIds(): iterable
+    {
+        yield from $this->deserialized->directlyDiscardedSpanIds();
+    }
+
+    /**
      * @return iterable<OTelResource>
      */
     public function resources(): iterable

--- a/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ExportTraceServiceRequest.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ExportTraceServiceRequest.php
@@ -32,10 +32,26 @@ class ExportTraceServiceRequest
      */
     public function spans(): iterable
     {
-        $discardedTraceIds = $this->collectDiscardedTraceIds();
+        // Collect span IDs of directly discarded spans (those with infra URL attributes).
+        // Then expand transitively: spans whose parent was discarded are also discarded.
+        // This correctly handles inferred child spans of infra requests (different trace from
+        // real test spans) without affecting spans that merely share a trace with a discarded span.
+        $discardedSpanIds = $this->collectDiscardedSpanIds();
+        do {
+            $changed = false;
+            foreach ($this->resourceSpans as $resourceSpans) {
+                foreach ($resourceSpans->spans() as $span) {
+                    if (!isset($discardedSpanIds[$span->id]) && $span->parentId !== null && isset($discardedSpanIds[$span->parentId])) {
+                        $discardedSpanIds[$span->id] = true;
+                        $changed = true;
+                    }
+                }
+            }
+        } while ($changed);
+
         foreach ($this->resourceSpans as $resourceSpans) {
             foreach ($resourceSpans->spans() as $span) {
-                if (!isset($discardedTraceIds[$span->traceId])) {
+                if (!isset($discardedSpanIds[$span->id])) {
                     yield $span;
                 }
             }
@@ -45,17 +61,17 @@ class ExportTraceServiceRequest
     /**
      * @return array<string, true>
      */
-    private function collectDiscardedTraceIds(): array
+    private function collectDiscardedSpanIds(): array
     {
-        $discardedTraceIds = [];
+        $discardedSpanIds = [];
         foreach ($this->resourceSpans as $resourceSpans) {
             foreach ($resourceSpans->scopeSpans as $scopeSpans) {
-                foreach ($scopeSpans->discardedTraceIds as $traceId) {
-                    $discardedTraceIds[$traceId] = true;
+                foreach ($scopeSpans->discardedSpanIds as $spanId) {
+                    $discardedSpanIds[$spanId] = true;
                 }
             }
         }
-        return $discardedTraceIds;
+        return $discardedSpanIds;
     }
 
     public function isEmptyAfterDeserialization(): bool

--- a/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ExportTraceServiceRequest.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ExportTraceServiceRequest.php
@@ -32,46 +32,24 @@ class ExportTraceServiceRequest
      */
     public function spans(): iterable
     {
-        // Collect span IDs of directly discarded spans (those with infra URL attributes).
-        // Then expand transitively: spans whose parent was discarded are also discarded.
-        // This correctly handles inferred child spans of infra requests (different trace from
-        // real test spans) without affecting spans that merely share a trace with a discarded span.
-        $discardedSpanIds = $this->collectDiscardedSpanIds();
-        do {
-            $changed = false;
-            foreach ($this->resourceSpans as $resourceSpans) {
-                foreach ($resourceSpans->spans() as $span) {
-                    if (!isset($discardedSpanIds[$span->id]) && $span->parentId !== null && isset($discardedSpanIds[$span->parentId])) {
-                        $discardedSpanIds[$span->id] = true;
-                        $changed = true;
-                    }
-                }
-            }
-        } while ($changed);
-
         foreach ($this->resourceSpans as $resourceSpans) {
-            foreach ($resourceSpans->spans() as $span) {
-                if (!isset($discardedSpanIds[$span->id])) {
-                    yield $span;
-                }
-            }
+            yield from $resourceSpans->spans();
         }
     }
 
     /**
-     * @return array<string, true>
+     * Span IDs of spans discarded during deserialization (matched infra URL filter).
+     * Used by AgentBackendComms to build the cross-batch transitive discard set.
+     *
+     * @return iterable<string>
      */
-    private function collectDiscardedSpanIds(): array
+    public function directlyDiscardedSpanIds(): iterable
     {
-        $discardedSpanIds = [];
         foreach ($this->resourceSpans as $resourceSpans) {
             foreach ($resourceSpans->scopeSpans as $scopeSpans) {
-                foreach ($scopeSpans->discardedSpanIds as $spanId) {
-                    $discardedSpanIds[$spanId] = true;
-                }
+                yield from $scopeSpans->discardedSpanIds;
             }
         }
-        return $discardedSpanIds;
     }
 
     public function isEmptyAfterDeserialization(): bool

--- a/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ExportTraceServiceRequest.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ExportTraceServiceRequest.php
@@ -32,9 +32,30 @@ class ExportTraceServiceRequest
      */
     public function spans(): iterable
     {
+        $discardedTraceIds = $this->collectDiscardedTraceIds();
         foreach ($this->resourceSpans as $resourceSpans) {
-            yield from $resourceSpans->spans();
+            foreach ($resourceSpans->spans() as $span) {
+                if (!isset($discardedTraceIds[$span->traceId])) {
+                    yield $span;
+                }
+            }
         }
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function collectDiscardedTraceIds(): array
+    {
+        $discardedTraceIds = [];
+        foreach ($this->resourceSpans as $resourceSpans) {
+            foreach ($resourceSpans->scopeSpans as $scopeSpans) {
+                foreach ($scopeSpans->discardedTraceIds as $traceId) {
+                    $discardedTraceIds[$traceId] = true;
+                }
+            }
+        }
+        return $discardedTraceIds;
     }
 
     public function isEmptyAfterDeserialization(): bool

--- a/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ScopeSpans.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ScopeSpans.php
@@ -16,12 +16,14 @@ use Opentelemetry\Proto\Trace\V1\Span as OTelProtoSpan;
 class ScopeSpans
 {
     /**
-     * @param Span[] $spans
+     * @param Span[]   $spans
+     * @param string[] $discardedTraceIds trace IDs of spans that were discarded from this scope
      */
     public function __construct(
         public readonly ?InstrumentationScope $scope,
         public readonly array $spans,
         public readonly string $schemaUrl,
+        public readonly array $discardedTraceIds = [],
     ) {
     }
 
@@ -30,17 +32,28 @@ class ScopeSpans
         $scope = DeserializationUtil::deserializeNullableFromOTelProto($source->getScope(), InstrumentationScope::deserializeFromOTelProto(...));
         $scopeName = $scope?->name;
 
+        $spans = [];
+        /** @var array<string, true> $discardedTraceIds */
+        $discardedTraceIds = [];
+        foreach ($source->getSpans() as $protoSpan) {
+            $span = self::deserializeSpanFromOTelProto($protoSpan, $scopeName, /* ref */ $discardedTraceIds);
+            if ($span !== null) {
+                $spans[] = $span;
+            }
+        }
+
         return new self(
             scope: $scope,
-            spans: DeserializationUtil::deserializeArrayFromOTelProto(
-                $source->getSpans(),
-                fn(OTelProtoSpan $protoSpan) => self::deserializeSpanFromOTelProto($protoSpan, $scopeName)
-            ),
+            spans: $spans,
             schemaUrl: $source->getSchemaUrl(),
+            discardedTraceIds: array_keys($discardedTraceIds),
         );
     }
 
-    private static function deserializeSpanFromOTelProto(OTelProtoSpan $source, ?string $scopeName): ?Span
+    /**
+     * @param array<string, true> $discardedTraceIds
+     */
+    private static function deserializeSpanFromOTelProto(OTelProtoSpan $source, ?string $scopeName, array &$discardedTraceIds): ?Span
     {
         DebugContext::getCurrentScope(/* out */ $dbgCtx);
         $dbgCtx->add(compact('source'));
@@ -49,6 +62,7 @@ class ScopeSpans
         if (($reason = Span::reasonToDiscard($span)) !== null) {
             AmbientContextForTests::loggerFactory()->loggerForClass(LogCategoryForTests::TEST_INFRA, __NAMESPACE__, __CLASS__, __FILE__)->addAllContext(compact('source'))
                 ->logDebug(__FUNCTION__)?->with(__LINE__, 'Span discarded', compact('reason', 'span'));
+            $discardedTraceIds[$span->traceId] = true;
             return null;
         }
 

--- a/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ScopeSpans.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ScopeSpans.php
@@ -17,13 +17,13 @@ class ScopeSpans
 {
     /**
      * @param Span[]   $spans
-     * @param string[] $discardedTraceIds trace IDs of spans that were discarded from this scope
+     * @param string[] $discardedSpanIds span IDs of spans that were directly discarded from this scope
      */
     public function __construct(
         public readonly ?InstrumentationScope $scope,
         public readonly array $spans,
         public readonly string $schemaUrl,
-        public readonly array $discardedTraceIds = [],
+        public readonly array $discardedSpanIds = [],
     ) {
     }
 
@@ -33,11 +33,11 @@ class ScopeSpans
         $scopeName = $scope?->name;
 
         $spans = [];
-        /** @var array<string, true> $discardedTraceIds */
-        $discardedTraceIds = [];
+        /** @var array<string, true> $discardedSpanIds */
+        $discardedSpanIds = [];
         /** @var OTelProtoSpan $protoSpan */
         foreach ($source->getSpans() as $protoSpan) {
-            $span = self::deserializeSpanFromOTelProto($protoSpan, $scopeName, /* ref */ $discardedTraceIds);
+            $span = self::deserializeSpanFromOTelProto($protoSpan, $scopeName, /* ref */ $discardedSpanIds);
             if ($span !== null) {
                 $spans[] = $span;
             }
@@ -47,14 +47,14 @@ class ScopeSpans
             scope: $scope,
             spans: $spans,
             schemaUrl: $source->getSchemaUrl(),
-            discardedTraceIds: array_keys($discardedTraceIds),
+            discardedSpanIds: array_keys($discardedSpanIds),
         );
     }
 
     /**
-     * @param array<string, true> $discardedTraceIds
+     * @param array<string, true> $discardedSpanIds
      */
-    private static function deserializeSpanFromOTelProto(OTelProtoSpan $source, ?string $scopeName, array &$discardedTraceIds): ?Span
+    private static function deserializeSpanFromOTelProto(OTelProtoSpan $source, ?string $scopeName, array &$discardedSpanIds): ?Span
     {
         DebugContext::getCurrentScope(/* out */ $dbgCtx);
         $dbgCtx->add(compact('source'));
@@ -63,7 +63,7 @@ class ScopeSpans
         if (($reason = Span::reasonToDiscard($span)) !== null) {
             AmbientContextForTests::loggerFactory()->loggerForClass(LogCategoryForTests::TEST_INFRA, __NAMESPACE__, __CLASS__, __FILE__)->addAllContext(compact('source'))
                 ->logDebug(__FUNCTION__)?->with(__LINE__, 'Span discarded', compact('reason', 'span'));
-            $discardedTraceIds[$span->traceId] = true;
+            $discardedSpanIds[$span->id] = true;
             return null;
         }
 

--- a/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ScopeSpans.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/OtlpData/ScopeSpans.php
@@ -35,6 +35,7 @@ class ScopeSpans
         $spans = [];
         /** @var array<string, true> $discardedTraceIds */
         $discardedTraceIds = [];
+        /** @var OTelProtoSpan $protoSpan */
         foreach ($source->getSpans() as $protoSpan) {
             $span = self::deserializeSpanFromOTelProto($protoSpan, $scopeName, /* ref */ $discardedTraceIds);
             if ($span !== null) {


### PR DESCRIPTION
## Problem
`InferredSpansComponentTest` asserts that all collected spans share the same traceId as the root span. This assertion was failing intermittently because spans from test infrastructure HTTP requests (status checks, process registration) were leaking into the mock OTel collector.

Specifically: when the PHP built-in server receives an infra request, the native extension creates an inferred root span for it. That root span was already being discarded (its `url.path` matches `/OTel_PHP_Distro_tests_infra/`). However, child inferred spans generated within the same infra request (e.g. a GuzzleHttp span) have no URL attributes and thus bypassed the filter - leaking into collected spans with a different traceId.

## Solution
Move the transitive discard logic to `AgentBackendComms::spans()`, which has visibility over all accumulated batches:

- `ScopeSpans` records the spanId of each directly discarded span (url.path filter match) in a new `discardedSpanIds` field.
- `ExportTraceServiceRequest` exposes `directlyDiscardedSpanIds()` so they can be collected without re-running the URL filter.
- `AgentBackendComms::spans()` filters in three steps over all batches:
  1. Collect all directly discarded spanIds across every batch.
  2. Transitively expand the discard set in a loop until stable (a span is also discarded if its parent spanId is in the set).
  3. Yield only the surviving spans.
