### PR TITLE
chore: Docker images housekeeping

### DIFF
--- a/docker/otel-tests/docker-compose.yml
+++ b/docker/otel-tests/docker-compose.yml
@@ -20,11 +20,11 @@ services:
       POSTGRESQL_HOST: ${POSTGRESQL_HOST:-postgresql}
 
   zipkin:
-    image: openzipkin/zipkin-slim
+    image: openzipkin/zipkin-slim:3.6.1@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
     ports:
     - 9411:9411
   jaeger:
-    image: jaegertracing/all-in-one
+    image: jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
     environment:
       COLLECTOR_ZIPKIN_HOST_PORT: 9412
     ports:
@@ -32,13 +32,13 @@ services:
     - 16686:16686
 
   collector:
-    image: otel/opentelemetry-collector-contrib
+    image: otel/opentelemetry-collector-contrib:0.156.0@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108
     command: [ "--config=/etc/otel-collector-config.yml" ]
     volumes:
       - ./files/collector/otel-collector-config.yml:/etc/otel-collector-config.yml
 
   rabbitmq:
-    image: rabbitmq:3
+    image: rabbitmq:3.13.7
     hostname: rabbitmq
     healthcheck:
       test: rabbitmq-diagnostics -q ping
@@ -66,13 +66,13 @@ services:
       - ./docker/kafka/update_run.sh:/tmp/update_run.sh
 
   mongodb:
-    image: mongo:4
+    image: mongo:4.4.30
     hostname: mongodb
     ports:
       - "27017:27017/tcp"
 
   mysql:
-    image: mysql:8.0
+    image: mysql:8.0.46
     hostname: mysql
     ports:
       - "3306:3306/tcp"

--- a/docker/otel-tests/docker-compose.yml
+++ b/docker/otel-tests/docker-compose.yml
@@ -25,8 +25,6 @@ services:
     - 9411:9411
   jaeger:
     image: jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
-    environment:
-      COLLECTOR_ZIPKIN_HOST_PORT: 9412
     ports:
     - 9412:9412
     - 16686:16686


### PR DESCRIPTION
Explicitly pin docker version to improve info/context available to renovate.

The jaegar tracing image has been switched as existing image is eol https://github.com/jaegertracing/jaeger/issues/6321