### PR TITLE
chore: Increase renovate rules to reduce volume

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,7 @@
       matchUpdateTypes: ['major'],
       matchManagers: ['docker-compose'],
       dependencyDashboardApproval: true,
-    },
+    }
   ],
   "labels": [
     "dependencies"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,13 +7,30 @@
   "packageRules": [
     {
       "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["patch", "digest"],
       "schedule": ["before 8am every weekday"]
     },
     {
       "matchUpdateTypes": ["minor", "major"],
       "schedule": ["before 8am on Monday"]
-    }
+    },
+    {
+      groupName: "infra [minor]",
+      matchCategories: ["ci", "docker"],
+      matchManagers: ['!dockerfile'],
+      matchUpdateTypes: ["minor"],
+      schedule: ["before 7am on Monday"],
+    },
+    {
+      groupName: 'opentelemetry-deps',
+      matchDepNames: ['open-telemetry/**'],
+      schedule: ['before 8am on Monday'],
+    },
+    {
+      matchUpdateTypes: ['major'],
+      matchManagers: ['docker-compose'],
+      dependencyDashboardApproval: true,
+    },
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
Add more rules to reduce the qty of renovate pr’s and bring down the queue.

key thing is that:

- all minor ci & docker updates are grouped together except for dockerfile dependencies
- All major docker compose updates need approval
- digest updates are added to the patches group
- group otel updates together