### PR TITLE
feat: capture HTTP request/response headers as span attributes

### DIFF
--- a/prod/php/OpenTelemetry/Distro/Traces/RootSpan.php
+++ b/prod/php/OpenTelemetry/Distro/Traces/RootSpan.php
@@ -25,6 +25,7 @@ use OpenTelemetry\SemConv\Incubating\Attributes\HttpIncubatingAttributes;
 use OpenTelemetry\SemConv\Attributes\UserAgentAttributes;
 use OpenTelemetry\SemConv\Version;
 use Psr\Http\Message\ServerRequestInterface;
+use OpenTelemetry\Distro\InstrumentationBridge;
 use OpenTelemetry\Distro\Util\WildcardListMatcher;
 
 class RootSpan
@@ -221,7 +222,7 @@ class RootSpan
         self::$responseHeaderHookRegistered = true;
         $headerNamesLower = array_map('strtolower', $headerNamesToCapture);
         $capturedHeaders = &self::$capturedResponseHeaders;
-        \OpenTelemetry\Instrumentation\hook(
+        InstrumentationBridge::singletonInstance()->hook(
             null,
             'header',
             pre: static function (?object $thisObj, array $params) use ($headerNamesLower, &$capturedHeaders): void {

--- a/prod/php/OpenTelemetry/Distro/Traces/RootSpan.php
+++ b/prod/php/OpenTelemetry/Distro/Traces/RootSpan.php
@@ -35,6 +35,11 @@ class RootSpan
 
     private static ?ContextStorageScopeInterface $rootScope = null;
 
+    /** @var array<string, string[]> Response headers captured via header() hook, reset each request */
+    private static array $capturedResponseHeaders = [];
+
+    private static bool $responseHeaderHookRegistered = false;
+
     private static function isCliSapi(): bool
     {
         return php_sapi_name() === 'cli';
@@ -105,6 +110,11 @@ class RootSpan
             );
         }
         $span = $spanBuilder->startSpan();
+        if (!self::isCliSapi()) {
+            self::captureRequestHeaders($request, $span);
+            self::$capturedResponseHeaders = [];
+            self::registerResponseHeaderHookIfNeeded();
+        }
         self::$rootScope = Context::storage()->attach($span->storeInContext($parent));
     }
 
@@ -169,7 +179,73 @@ class RootSpan
             }
         }
 
+        self::captureResponseHeaders($span);
         $span->end();
+    }
+
+    /**
+     * @param \OpenTelemetry\API\Trace\SpanInterface $span
+     */
+    private static function captureRequestHeaders(ServerRequestInterface $request, \OpenTelemetry\API\Trace\SpanInterface $span): void
+    {
+        /** @var string[] $headerNames */
+        $headerNames = Configuration::getList('OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS', []);
+        foreach ($headerNames as $name) {
+            $values = $request->getHeader($name);
+            if ($values !== []) {
+                $span->setAttribute('http.request.header.' . strtolower($name), $values);
+            }
+        }
+    }
+
+    /**
+     * @param \OpenTelemetry\API\Trace\SpanInterface $span
+     */
+    private static function captureResponseHeaders(\OpenTelemetry\API\Trace\SpanInterface $span): void
+    {
+        foreach (self::$capturedResponseHeaders as $name => $values) {
+            $span->setAttribute('http.response.header.' . $name, $values);
+        }
+    }
+
+    private static function registerResponseHeaderHookIfNeeded(): void
+    {
+        if (self::$responseHeaderHookRegistered) {
+            return;
+        }
+        /** @var string[] $headerNamesToCapture */
+        $headerNamesToCapture = Configuration::getList('OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS', []);
+        if ($headerNamesToCapture === []) {
+            return;
+        }
+        self::$responseHeaderHookRegistered = true;
+        $headerNamesLower = array_map('strtolower', $headerNamesToCapture);
+        $capturedHeaders = &self::$capturedResponseHeaders;
+        \OpenTelemetry\Instrumentation\hook(
+            null,
+            'header',
+            pre: static function (?object $thisObj, array $params) use ($headerNamesLower, &$capturedHeaders): void {
+                $headerStr = $params[0] ?? null;
+                $replace = $params[1] ?? true;
+                if (!is_string($headerStr)) {
+                    return;
+                }
+                $colonPos = strpos($headerStr, ':');
+                if ($colonPos === false) {
+                    return;
+                }
+                $name = strtolower(trim(substr($headerStr, 0, $colonPos)));
+                $value = trim(substr($headerStr, $colonPos + 1));
+                if (!in_array($name, $headerNamesLower, true)) {
+                    return;
+                }
+                if ($replace !== false) {
+                    $capturedHeaders[$name] = [$value];
+                } else {
+                    $capturedHeaders[$name][] = $value;
+                }
+            }
+        );
     }
 
     private static function getOptionalServerVarElement(string $key): mixed

--- a/tests/OTelDistroTests/ComponentTests/HttpHeaderCaptureTest.php
+++ b/tests/OTelDistroTests/ComponentTests/HttpHeaderCaptureTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OTelDistroTests\ComponentTests;
+
+use OTelDistroTests\ComponentTests\Util\AppCodeHostParams;
+use OTelDistroTests\ComponentTests\Util\AppCodeTarget;
+use OTelDistroTests\ComponentTests\Util\ComponentTestCaseBase;
+use OTelDistroTests\ComponentTests\Util\AppCodeRequestParams;
+use OTelDistroTests\ComponentTests\Util\HttpAppCodeRequestParams;
+use OTelDistroTests\ComponentTests\Util\WaitForOTelSignalCounts;
+use OTelDistroTests\Util\MixedMap;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @group smoke
+ * @group does_not_require_external_services
+ */
+final class HttpHeaderCaptureTest extends ComponentTestCaseBase
+{
+    private const CAPTURE_REQUEST_HEADERS_ENV = 'OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS';
+    private const CAPTURE_RESPONSE_HEADERS_ENV = 'OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS';
+
+    private const REQUEST_HEADER_NAME = 'x-request-id';
+    private const REQUEST_HEADER_VALUE = 'test-request-id-abc';
+    private const RESPONSE_HEADER_NAME = 'x-custom-response';
+    private const RESPONSE_HEADER_VALUE = 'custom-value-xyz';
+
+    public static function appCodeForTestHeaderCapture(MixedMap $_appCodeRequestArgs): void
+    {
+        header('X-Custom-Response: ' . self::RESPONSE_HEADER_VALUE);
+    }
+
+    private function implTestHttpHeaderCapture(): void
+    {
+        if (!self::isMainAppCodeHostHttp()) {
+            return;
+        }
+
+        $testCaseHandle = $this->getTestCaseHandle();
+
+        $appCodeHost = $testCaseHandle->ensureMainAppCodeHost(
+            function (AppCodeHostParams $appCodeHostParams): void {
+                self::disableTimingDependentFeatures($appCodeHostParams);
+                $appCodeHostParams->setAdditionalEnvVar(self::CAPTURE_REQUEST_HEADERS_ENV, self::REQUEST_HEADER_NAME);
+                $appCodeHostParams->setAdditionalEnvVar(self::CAPTURE_RESPONSE_HEADERS_ENV, self::RESPONSE_HEADER_NAME);
+            }
+        );
+
+        $appCodeHost->execAppCode(
+            AppCodeTarget::asRouted([__CLASS__, 'appCodeForTestHeaderCapture']),
+            function (AppCodeRequestParams $requestParams): void {
+                assert($requestParams instanceof HttpAppCodeRequestParams);
+                $requestParams->extraHeaders[self::REQUEST_HEADER_NAME] = self::REQUEST_HEADER_VALUE;
+            }
+        );
+
+        // +1 transaction span (inferred spans disabled)
+        $agentBackendComms = $testCaseHandle->waitForEnoughAgentBackendComms(WaitForOTelSignalCounts::spans(1));
+
+        $rootSpan = $agentBackendComms->singleRootSpan();
+
+        Assert::assertTrue(
+            $rootSpan->attributes->keyExists('http.request.header.' . self::REQUEST_HEADER_NAME),
+            'Expected http.request.header.' . self::REQUEST_HEADER_NAME . ' attribute on root span'
+        );
+
+        Assert::assertTrue(
+            $rootSpan->attributes->keyExists('http.response.header.' . self::RESPONSE_HEADER_NAME),
+            'Expected http.response.header.' . self::RESPONSE_HEADER_NAME . ' attribute on root span'
+        );
+    }
+
+    public function testHttpHeaderCapture(): void
+    {
+        $this->runAndEscalateLogLevelOnFailure(
+            self::buildDbgDescForTest(__CLASS__, __FUNCTION__),
+            fn() => $this->implTestHttpHeaderCapture()
+        );
+    }
+}

--- a/tests/OTelDistroTests/ComponentTests/HttpHeaderCaptureTest.php
+++ b/tests/OTelDistroTests/ComponentTests/HttpHeaderCaptureTest.php
@@ -10,7 +10,6 @@ use OTelDistroTests\ComponentTests\Util\ComponentTestCaseBase;
 use OTelDistroTests\ComponentTests\Util\AppCodeRequestParams;
 use OTelDistroTests\ComponentTests\Util\HttpAppCodeRequestParams;
 use OTelDistroTests\ComponentTests\Util\WaitForOTelSignalCounts;
-use OTelDistroTests\Util\MixedMap;
 use PHPUnit\Framework\Assert;
 
 /**
@@ -27,7 +26,7 @@ final class HttpHeaderCaptureTest extends ComponentTestCaseBase
     private const RESPONSE_HEADER_NAME = 'x-custom-response';
     private const RESPONSE_HEADER_VALUE = 'custom-value-xyz';
 
-    public static function appCodeForTestHeaderCapture(MixedMap $_appCodeRequestArgs): void
+    public static function appCodeForTestHeaderCapture(): void
     {
         header('X-Custom-Response: ' . self::RESPONSE_HEADER_VALUE);
     }

--- a/tests/OTelDistroTests/ComponentTests/HttpHeaderCaptureTest.php
+++ b/tests/OTelDistroTests/ComponentTests/HttpHeaderCaptureTest.php
@@ -34,7 +34,7 @@ final class HttpHeaderCaptureTest extends ComponentTestCaseBase
 
     private function implTestHttpHeaderCapture(): void
     {
-        if (!self::isMainAppCodeHostHttp()) {
+        if ($this->skipIfMainAppCodeHostIsNotHttp()) {
             return;
         }
 
@@ -61,14 +61,14 @@ final class HttpHeaderCaptureTest extends ComponentTestCaseBase
 
         $rootSpan = $agentBackendComms->singleRootSpan();
 
-        Assert::assertTrue(
-            $rootSpan->attributes->keyExists('http.request.header.' . self::REQUEST_HEADER_NAME),
-            'Expected http.request.header.' . self::REQUEST_HEADER_NAME . ' attribute on root span'
+        Assert::assertSame(
+            [self::REQUEST_HEADER_VALUE],
+            $rootSpan->attributes->getValue('http.request.header.' . self::REQUEST_HEADER_NAME)
         );
 
-        Assert::assertTrue(
-            $rootSpan->attributes->keyExists('http.response.header.' . self::RESPONSE_HEADER_NAME),
-            'Expected http.response.header.' . self::RESPONSE_HEADER_NAME . ' attribute on root span'
+        Assert::assertSame(
+            [self::RESPONSE_HEADER_VALUE],
+            $rootSpan->attributes->getValue('http.response.header.' . self::RESPONSE_HEADER_NAME)
         );
     }
 

--- a/tests/OTelDistroTests/ComponentTests/Util/HttpAppCodeRequestParams.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/HttpAppCodeRequestParams.php
@@ -16,6 +16,8 @@ final class HttpAppCodeRequestParams extends AppCodeRequestParams
     public string $httpRequestMethod = self::DEFAULT_HTTP_REQUEST_METHOD;
     public UrlParts $urlParts;
     public ?int $expectedHttpResponseStatusCode = HttpStatusCodes::OK;
+    /** @var array<string, string> */
+    public array $extraHeaders = [];
 
     public function __construct(HttpServerHandle $httpServerHandle, AppCodeTarget $appCodeTarget)
     {

--- a/tests/OTelDistroTests/ComponentTests/Util/HttpClientUtilForTests.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/HttpClientUtilForTests.php
@@ -47,7 +47,7 @@ final class HttpClientUtilForTests
 
         $logDebug?->with(__LINE__, 'Sending HTTP request to app code...');
 
-        $response = HttpClientUtilForTests::sendRequest($requestParams->httpRequestMethod, $requestParams->urlParts, $requestParams->dataPerRequest);
+        $response = HttpClientUtilForTests::sendRequest($requestParams->httpRequestMethod, $requestParams->urlParts, $requestParams->dataPerRequest, $requestParams->extraHeaders);
         $actualResponseStatusCode = $response->getStatusCode();
         $localLogger->addAllContext(compact('actualResponseStatusCode'));
         $dbgCtx->add(compact('actualResponseStatusCode'));

--- a/tests/OTelDistroTests/ComponentTests/Util/OtlpData/Attributes.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/OtlpData/Attributes.php
@@ -71,15 +71,23 @@ final class Attributes implements ArrayReadInterface, Countable, LoggableInterfa
             return null;
         }
 
+        return self::extractAnyValue($anyValue, compact('keyValue'));
+    }
+
+    /**
+     * @param array<string, mixed> $dbgCtx
+     * @return AttributeValue
+     */
+    private static function extractAnyValue(\Opentelemetry\Proto\Common\V1\AnyValue $anyValue, array $dbgCtx = []): array|bool|float|int|null|string
+    {
         if ($anyValue->hasArrayValue()) {
             $arrayValue = $anyValue->getArrayValue();
             if ($arrayValue === null) {
                 return null;
             }
             $result = [];
-            $arrayValues = $arrayValue->getValues();
-            foreach ($arrayValues as $repeatedFieldSubValue) {
-                $result[] = $repeatedFieldSubValue;
+            foreach ($arrayValue->getValues() as $element) {
+                $result[] = self::extractAnyValue($element, $dbgCtx);
             }
             return $result;
         }
@@ -122,7 +130,7 @@ final class Attributes implements ArrayReadInterface, Countable, LoggableInterfa
             return $anyValue->getStringValue();
         }
 
-        Assert::fail('Unknown value type; ' . LoggableToString::convert(compact('keyValue')));
+        Assert::fail('Unknown value type; ' . LoggableToString::convert($dbgCtx));
     }
 
     #[Override]

--- a/tests/OTelDistroTests/ComponentTests/Util/OtlpData/Attributes.php
+++ b/tests/OTelDistroTests/ComponentTests/Util/OtlpData/Attributes.php
@@ -87,6 +87,7 @@ final class Attributes implements ArrayReadInterface, Countable, LoggableInterfa
             }
             $result = [];
             foreach ($arrayValue->getValues() as $element) {
+                Assert::assertInstanceOf(\Opentelemetry\Proto\Common\V1\AnyValue::class, $element);
                 $result[] = self::extractAnyValue($element, $dbgCtx);
             }
             return $result;


### PR DESCRIPTION
Implements OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS and OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS.

Request headers are read from the PSR-7 ServerRequestInterface at span start. Response headers are captured via a hook on PHP's header() function (reliable across all SAPIs including cli-server, where headers_list() in shutdown handlers is unreliable).